### PR TITLE
🚀 systemd service for Debian

### DIFF
--- a/debian/dirs
+++ b/debian/dirs
@@ -1,0 +1,1 @@
+/var/log/chleb/

--- a/debian/dirs
+++ b/debian/dirs
@@ -1,1 +1,1 @@
-/var/log/chleb/
+/var/log/chleb-bible-search/

--- a/debian/install
+++ b/debian/install
@@ -1,0 +1,1 @@
+etc/chleb.service /etc/systemd/system/

--- a/debian/install
+++ b/debian/install
@@ -1,2 +1,2 @@
-etc/chleb.service /etc/systemd/system/
-etc/log4perl.conf /etc/chleb/
+etc/chleb-bible-search.service /etc/systemd/system/
+etc/log4perl.conf /etc/chleb-bible-search/

--- a/debian/install
+++ b/debian/install
@@ -1,1 +1,2 @@
 etc/chleb.service /etc/systemd/system/
+etc/log4perl.conf /etc/chleb/

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,5 +1,21 @@
 #!/bin/sh
 
+[ -z "$SERVER_USER" ] && SERVER_USER=chleb
+[ -z "$SERVER_NAME" ] && SERVER_NAME="Chleb Bible Search"
+
+if ! getent passwd | grep -q "^$SERVER_USER:"; then
+	echo -n "Adding system user $SERVER_USER.."
+	adduser --quiet \
+		--system \
+		--no-create-home \
+		--disabled-password \
+		$SERVER_USER 2>/dev/null || true
+	echo "..done"
+fi
+
+usermod -c "$SERVER_NAME" $SERVER_USER
+chown $SERVER_USER /var/log/chleb-bible-search/default.log
+
 /usr/bin/systemctl start chleb-bible-search
 /usr/bin/systemctl enable chleb-bible-search
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+/usr/bin/systemctl start chleb-bible-search
+/usr/bin/systemctl enable chleb-bible-search
+
+exit 0

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,11 +1,6 @@
 #!/bin/sh
 
-if test "$EUID" = "0"
-	>&2 echo "ERROR: Run this script as root"
-	exit 1
-then
-	/usr/bin/systemctl disable chleb-bible-search
-	/usr/bin/systemctl stop chleb-bible-search
-fi
+/usr/bin/systemctl disable chleb-bible-search
+/usr/bin/systemctl stop chleb-bible-search
 
 exit 0

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+if test "$EUID" = "0"
+	>&2 echo "ERROR: Run this script as root"
+	exit 1
+then
+	/usr/bin/systemctl disable chleb-bible-search
+	/usr/bin/systemctl stop chleb-bible-search
+fi
+
+exit 0

--- a/etc/chleb-bible-search.service
+++ b/etc/chleb-bible-search.service
@@ -8,7 +8,6 @@ ExecStart=/usr/bin/perl /usr/share/perl5/Religion/Bible/Verses/Server.pm
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 RestartPreventExitStatus=255
-Type=notify
 RuntimeDirectory=chleb
 RuntimeDirectoryMode=0755
 Type=exec

--- a/etc/chleb-bible-search.service
+++ b/etc/chleb-bible-search.service
@@ -14,6 +14,7 @@ RuntimeDirectoryMode=0755
 Type=exec
 Nice=15
 Restart=always
+User=chleb
 
 [Install]
 WantedBy=multi-user.target

--- a/etc/chleb-bible-search.service
+++ b/etc/chleb-bible-search.service
@@ -3,7 +3,7 @@ Description=Chleb Bible Search
 After=network.target
 
 [Service]
-EnvironmentFile=-/etc/default/chleb
+EnvironmentFile=-/etc/default/chleb-bible-search
 ExecStart=/usr/bin/perl /usr/share/perl5/Religion/Bible/Verses/Server.pm
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
@@ -17,4 +17,4 @@ Restart=always
 
 [Install]
 WantedBy=multi-user.target
-Alias=chleb.service
+Alias=chleb-bible-search.service

--- a/etc/chleb.service
+++ b/etc/chleb.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Chleb Bible Search
+After=network.target
+
+[Service]
+EnvironmentFile=-/etc/default/chleb
+ExecStart=/usr/bin/perl /usr/share/perl5/Religion/Bible/Verses/Server.pm
+ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
+RestartPreventExitStatus=255
+Type=notify
+RuntimeDirectory=chleb
+RuntimeDirectoryMode=0755
+Type=exec
+Nice=15
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+Alias=chleb.service

--- a/etc/log4perl.conf
+++ b/etc/log4perl.conf
@@ -1,7 +1,7 @@
 log4perl.logger.bible = DEBUG, FileAppndrDefault, SCREEN
 
 log4perl.appender.FileAppndrDefault = Log::Log4perl::Appender::File
-log4perl.appender.FileAppndrDefault.filename = /var/log/bible/default.log
+log4perl.appender.FileAppndrDefault.filename = /var/log/chleb/default.log
 log4perl.appender.FileAppndrDefault.layout = Log::Log4perl::Layout::PatternLayout
 log4perl.appender.FileAppndrDefault.layout.ConversionPattern = [%d{yyyy-MM-dd HH:mm:ss.SSS}] [%-5p] (%C L%L): %m\n
 

--- a/etc/log4perl.conf
+++ b/etc/log4perl.conf
@@ -1,7 +1,7 @@
-log4perl.logger.bible = DEBUG, FileAppndrDefault, SCREEN
+log4perl.logger.chleb = DEBUG, FileAppndrDefault, SCREEN
 
 log4perl.appender.FileAppndrDefault = Log::Log4perl::Appender::File
-log4perl.appender.FileAppndrDefault.filename = /var/log/chleb/default.log
+log4perl.appender.FileAppndrDefault.filename = /var/log/chleb-bible-search/default.log
 log4perl.appender.FileAppndrDefault.layout = Log::Log4perl::Layout::PatternLayout
 log4perl.appender.FileAppndrDefault.layout.ConversionPattern = [%d{yyyy-MM-dd HH:mm:ss.SSS}] [%-5p] (%C L%L): %m\n
 

--- a/lib/Religion/Bible/Verses/DI/Container.pm
+++ b/lib/Religion/Bible/Verses/DI/Container.pm
@@ -37,7 +37,12 @@ use Log::Log4perl;
 has logger => (is => 'rw', lazy => 1, builder => '_makeLogger');
 
 sub _makeLogger {
-	Log::Log4perl->init('etc/log4perl.conf');
+	foreach my $path ('etc/log4perl.conf', '/etc/chleb/log4perl.conf') {
+		next unless (-e $path);
+		Log::Log4perl->init($path);
+		last;
+	}
+
 	return Log::Log4perl->get_logger('bible');
 }
 

--- a/lib/Religion/Bible/Verses/DI/Container.pm
+++ b/lib/Religion/Bible/Verses/DI/Container.pm
@@ -37,13 +37,13 @@ use Log::Log4perl;
 has logger => (is => 'rw', lazy => 1, builder => '_makeLogger');
 
 sub _makeLogger {
-	foreach my $path ('etc/log4perl.conf', '/etc/chleb/log4perl.conf') {
+	foreach my $path ('etc/log4perl.conf', '/etc/chleb-bible-search/log4perl.conf') {
 		next unless (-e $path);
 		Log::Log4perl->init($path);
 		last;
 	}
 
-	return Log::Log4perl->get_logger('bible');
+	return Log::Log4perl->get_logger('chleb');
 }
 
 1;

--- a/lib/Religion/Bible/Verses/DI/MockLogger.pm
+++ b/lib/Religion/Bible/Verses/DI/MockLogger.pm
@@ -36,13 +36,16 @@ use warnings;
 sub BUILD {
 }
 
+sub info {
+}
+
+sub warn {
+}
+
 sub debug {
 }
 
 sub trace {
-}
-
-sub warn {
 }
 
 1;

--- a/lib/Religion/Bible/Verses/Server.pm
+++ b/lib/Religion/Bible/Verses/Server.pm
@@ -52,7 +52,7 @@ sub dic {
 
 sub __title {
 	my ($self) = @_;
-	$self->dic->logger->info("Started Chleb Bible Server: \"But he answered and said, It is written, Man shall not live by bread alone, but by every word that proceedeth out of the mouth of God.\" (Matthew 4:4)");
+	$self->dic->logger->info("Started Chleb Bible Server: \"Man shall not live by bread alone, but by every word that proceedeth out of the mouth of God.\" (Matthew 4:4)");
 	return;
 }
 

--- a/lib/Religion/Bible/Verses/Server.pm
+++ b/lib/Religion/Bible/Verses/Server.pm
@@ -52,7 +52,7 @@ sub dic {
 
 sub __title {
 	my ($self) = @_;
-	$self->dic->logger->info('Started Chleb Server');
+	$self->dic->logger->info("Started Chleb Bible Server: \"But he answered and said, It is written, Man shall not live by bread alone, but by every word that proceedeth out of the mouth of God.\" (Matthew 4:4)");
 	return;
 }
 

--- a/lib/Religion/Bible/Verses/Server.pm
+++ b/lib/Religion/Bible/Verses/Server.pm
@@ -34,11 +34,26 @@ use strict;
 use warnings;
 use JSON;
 use Religion::Bible::Verses;
+use Religion::Bible::Verses::DI::Container;
 use UUID::Tiny ':std';
 
 sub new {
 	my ($class) = @_;
-	return bless({}, $class);
+	my $object = bless({}, $class);
+
+	$object->__title();
+
+	return $object;
+}
+
+sub dic {
+	return Religion::Bible::Verses::DI::Container->instance;
+}
+
+sub __title {
+	my ($self) = @_;
+	$self->dic->logger->info('Started Chleb Server');
+	return;
 }
 
 sub __json {

--- a/lib/Religion/Bible/Verses/Server.pm
+++ b/lib/Religion/Bible/Verses/Server.pm
@@ -259,6 +259,7 @@ get '/1/search' => sub {
 
 unless (caller()) {
 	$server = Religion::Bible::Verses::Server->new();
+	$0 = 'chleb-bible-search [server]';
 	dance;
 
 	exit(EXIT_SUCCESS);

--- a/t/Server_votd.t
+++ b/t/Server_votd.t
@@ -48,8 +48,8 @@ use Test::More 0.96;
 sub setUp {
 	my ($self) = @_;
 
-	$self->sut(Religion::Bible::Verses::Server->new());
 	$self->__mockLogger();
+	$self->sut(Religion::Bible::Verses::Server->new());
 
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
We switch the user to ‘chleb’ to avoid running as root, and install a systemd service. For consistency, we use the paths ‘chleb-bible-search’.

We we set a title for the running service and log when the server is started.