### PR TITLE
✨ Added parental mode

### DIFF
--- a/etc/main.conf
+++ b/etc/main.conf
@@ -1,7 +1,10 @@
 [votd_exclude]
 term1=fornication
 term2=circumcision
+term3=circumcised
 ref1=Lev 20:13
 ref2=Gen 19:8
 ref3=Psa 137:9
 ref4=Judges 19:22-29
+ref5=Kefir 50:1
+ref6=Rev 1000:11

--- a/etc/main.conf
+++ b/etc/main.conf
@@ -1,0 +1,7 @@
+[votd_exclude]
+term1=fornication
+term2=circumcision
+ref1=Lev 20:13
+ref2=Gen 19:8
+ref3=Psa 137:9
+ref4=Judges 19:22-29

--- a/lib/Religion/Bible/Verses.pm
+++ b/lib/Religion/Bible/Verses.pm
@@ -55,6 +55,9 @@ BEGIN {
 }
 
 sub BUILD {
+	my ($self) = @_;
+	$self->dic->bible($self); # self registration
+	return;
 }
 
 sub getBookByShortName {

--- a/lib/Religion/Bible/Verses.pm
+++ b/lib/Religion/Bible/Verses.pm
@@ -150,7 +150,7 @@ sub votd {
 	my ($self, $params) = @_;
 	my ($when, $version, $parental) = @{$params}{qw(when version parental)};
 
-	$when = $self->__resolveISO8601($when);
+	$when = $self->_resolveISO8601($when);
 	$when = $when->set_time_zone('UTC')->truncate(to => 'day');
 
 	my $verse;

--- a/lib/Religion/Bible/Verses.pm
+++ b/lib/Religion/Bible/Verses.pm
@@ -168,10 +168,8 @@ sub votd {
 		my $verseOrdinal = 1 + ($seed % $chapter->verseCount);
 		$verse = $chapter->getVerseByOrdinal($verseOrdinal);
 
-		if (!$parental || !$verse->parental) {
-			$self->dic->logger->trace('Skipping ' . $verse->toString() . ' because of parental mode');
-			last;
-		}
+		last if (!$parental || !$verse->parental);
+		$self->dic->logger->debug('Skipping ' . $verse->toString() . ' because of parental mode');
 	}
 
 	$self->dic->logger->debug($verse->toString());

--- a/lib/Religion/Bible/Verses/Base.pm
+++ b/lib/Religion/Bible/Verses/Base.pm
@@ -46,21 +46,23 @@ sub __makeDIContainer {
 	return Religion::Bible::Verses::DI::Container->new();
 }
 
-sub __resolveISO8601 {
+sub _resolveISO8601 {
 	my ($self, $iso8601) = @_;
 
 	$iso8601 ||= DateTime->now; # The default is the current time
 	if (my $ref = blessed($iso8601)) {
 		if ($ref->isa('DateTime')) {
-			$self->dic->logger->error('NULL in __resolveISO8601!') unless (defined($iso8601));
+			$self->dic->logger->error('NULL in _resolveISO8601!') unless (defined($iso8601));
 			return $iso8601;
 		} else {
 			die('Unsupported blessed time format');
 		}
 	}
 
-	my $format = DateTime::Format::Strptime->new(pattern => '%FT%T%z');
+	$iso8601 =~ s/ /+/g; # Fix bad client behavior
 	$self->dic->logger->trace("parsing date string '$iso8601'");
+
+	my $format = DateTime::Format::Strptime->new(pattern => '%FT%T%z');
 	eval {
 		$iso8601 = $format->parse_datetime($iso8601);
 	};
@@ -69,7 +71,7 @@ sub __resolveISO8601 {
 		die('Unsupported ISO-8601 time format: ' . $evalError);
 	}
 
-	$self->dic->logger->error('NULL in __resolveISO8601!') unless (defined($iso8601));
+	$self->dic->logger->error('NULL in _resolveISO8601!') unless (defined($iso8601));
 	return $iso8601;
 }
 

--- a/lib/Religion/Bible/Verses/Base.pm
+++ b/lib/Religion/Bible/Verses/Base.pm
@@ -52,6 +52,7 @@ sub __resolveISO8601 {
 	$iso8601 ||= DateTime->now; # The default is the current time
 	if (my $ref = blessed($iso8601)) {
 		if ($ref->isa('DateTime')) {
+			$self->dic->logger->error('NULL in __resolveISO8601!') unless (defined($iso8601));
 			return $iso8601;
 		} else {
 			die('Unsupported blessed time format');
@@ -59,6 +60,7 @@ sub __resolveISO8601 {
 	}
 
 	my $format = DateTime::Format::Strptime->new(pattern => '%FT%T%z');
+	$self->dic->logger->trace("parsing date string '$iso8601'");
 	eval {
 		$iso8601 = $format->parse_datetime($iso8601);
 	};
@@ -67,6 +69,7 @@ sub __resolveISO8601 {
 		die('Unsupported ISO-8601 time format: ' . $evalError);
 	}
 
+	$self->dic->logger->error('NULL in __resolveISO8601!') unless (defined($iso8601));
 	return $iso8601;
 }
 

--- a/lib/Religion/Bible/Verses/DI/Container.pm
+++ b/lib/Religion/Bible/Verses/DI/Container.pm
@@ -36,6 +36,8 @@ use Log::Log4perl;
 use Religion::Bible::Verses::DI::Config;
 use Religion::Bible::Verses::Exclusions;
 
+has bible => (is => 'rw');
+
 has logger => (is => 'rw', lazy => 1, builder => '_makeLogger');
 
 has config => (is => 'rw', lazy => 1, builder => '_makeConfig');

--- a/lib/Religion/Bible/Verses/DI/MockLogger.pm
+++ b/lib/Religion/Bible/Verses/DI/MockLogger.pm
@@ -33,22 +33,42 @@ use Moose;
 use strict;
 use warnings;
 
+use Test::More;
+
 sub BUILD {
+	return;
+}
+
+sub log {
+	my ($self, $msg) = @_;
+	return unless ($ENV{TEST_VERBOSE});
+	diag($msg);
+	return;
 }
 
 sub info {
+	my ($self, $msg) = @_;
+	return $self->log($msg);
 }
 
 sub error {
+	my ($self, $msg) = @_;
+	return $self->log($msg);
 }
 
 sub warn {
+	my ($self, $msg) = @_;
+	return $self->log($msg);
 }
 
 sub debug {
+	my ($self, $msg) = @_;
+	return $self->log($msg);
 }
 
 sub trace {
+	my ($self, $msg) = @_;
+	return $self->log($msg);
 }
 
 1;

--- a/lib/Religion/Bible/Verses/DI/MockLogger.pm
+++ b/lib/Religion/Bible/Verses/DI/MockLogger.pm
@@ -39,6 +39,9 @@ sub BUILD {
 sub info {
 }
 
+sub error {
+}
+
 sub warn {
 }
 

--- a/lib/Religion/Bible/Verses/Exclusions.pm
+++ b/lib/Religion/Bible/Verses/Exclusions.pm
@@ -93,7 +93,7 @@ sub __makeRefs {
 
 			if ($bookName) {
 				my $verse;
-				$verseOrdinalEnd = $verseOrdinalStart if (!$verseOrdinalEnd || $verseOrdinalEnd > $verseOrdinalStart);
+				$verseOrdinalEnd = $verseOrdinalStart if (!$verseOrdinalEnd || $verseOrdinalEnd < $verseOrdinalStart);
 				$self->dic->logger->trace(sprintf('Loop %d -> %d', $verseOrdinalStart, $verseOrdinalEnd));
 				for (my $verseOrdinal = $verseOrdinalStart; $verseOrdinal <= $verseOrdinalEnd; $verseOrdinal++) {
 					$self->dic->logger->trace(sprintf('Loop iteration %d', $verseOrdinal));

--- a/lib/Religion/Bible/Verses/Exclusions.pm
+++ b/lib/Religion/Bible/Verses/Exclusions.pm
@@ -114,4 +114,32 @@ sub __makeRefs {
 	return \@refs;
 }
 
+sub isExcluded {
+	my ($self, $verse) = @_;
+	return 1 if ($self->__isExcludedRef($verse));
+	return $self->__isExcludedTerm($verse->text);
+}
+
+sub __isExcludedRef {
+	my ($self, $verse) = @_;
+	return 0; # TODO
+}
+
+sub __isExcludedTerm {
+	my ($self, $text) = @_;
+
+	my $excluded = 0;
+	foreach my $term (@{ $self->terms }) {
+		if (index($text, $term) > -1) {
+			$excluded = 1;
+			$self->dic->logger->trace("term '$term', text '$text': MATCH");
+			last;
+		} else {
+			$self->dic->logger->trace("term '$term', text '$text': MISMATCH");
+		}
+	}
+
+	return $excluded;
+}
+
 1;

--- a/lib/Religion/Bible/Verses/Exclusions.pm
+++ b/lib/Religion/Bible/Verses/Exclusions.pm
@@ -122,7 +122,17 @@ sub isExcluded {
 
 sub __isExcludedRef {
 	my ($self, $verse) = @_;
-	return 0; # TODO
+
+	my $excluded = 0;
+	foreach my $ref (@{ $self->refs }) {
+		if ($verse->equals($ref)) {
+			$excluded = 1;
+			$self->dic->logger->trace('VERSE REF MATCH! ' . $ref->toString());
+			last;
+		}
+	}
+
+	return $excluded;
 }
 
 sub __isExcludedTerm {

--- a/lib/Religion/Bible/Verses/Exclusions.pm
+++ b/lib/Religion/Bible/Verses/Exclusions.pm
@@ -39,12 +39,12 @@ use Readonly;
 
 Readonly my $SECTION_NAME => 'votd_exclude';
 
-has list => (is => 'ro', isa => 'ArrayRef[Religion::Bible::Verses::Verse]', lazy => 1, default => \&__makeList);
+has refs => (is => 'ro', isa => 'ArrayRef[Religion::Bible::Verses::Verse]', lazy => 1, default => \&__makeRefs);
 has terms => (is => 'ro', isa => 'ArrayRef[Str]', lazy => 1, default => \&__makeTerms);
 
 sub BUILD {
 	my ($self) = @_;
-	#$self->list;
+	$self->refs;
 	$self->terms;
 	return;
 }
@@ -68,11 +68,23 @@ sub __makeTerms {
 	return \@terms;
 }
 
-sub __makeList {
+sub __makeRefs {
 	my ($self) = @_;
 
-	$self->dic->logger->debug('TODO: Excluded verses not loaded');
-	return [ ]; # FIXME
+	my @refs;
+	my $i = 0;
+	my $string = '';
+	my $length = 0;
+	do {
+		my $key = sprintf('ref%d', ++$i);
+		$string = $self->dic->config->get($SECTION_NAME, $key, '');
+		if ($length = length($string)) {
+			#push(@refs, $string); # TODO yeah but?
+		}
+	} while ($length > 0);
+
+	$self->dic->logger->debug(sprintf('Loaded %d excluded VoTD references', scalar(@refs)));
+	return \@refs;
 }
 
 1;

--- a/lib/Religion/Bible/Verses/Exclusions.pm
+++ b/lib/Religion/Bible/Verses/Exclusions.pm
@@ -81,10 +81,12 @@ sub __makeRefs {
 		$string = $self->dic->config->get($SECTION_NAME, $key, '');
 		if ($length = length($string)) {
 			my ($bookName, $chapterOrdinal, $verseOrdinalStart, $verseOrdinalEnd);
-			if ($string =~ m/^(\w+)\s+(\d+):(\d+)$/) {
-				($bookName, $chapterOrdinal, $verseOrdinalStart) = ($1, $2, $3);
-			} elsif ($string =~ m/^(\w+)\s+(\d+):(\d+)-(\d+)$/) {
+			if ($string =~ m/^(\w+)\s+(\d+):(\d+)-(\d+)$/) {
 				($bookName, $chapterOrdinal, $verseOrdinalStart, $verseOrdinalEnd) = ($1, $2, $3, $4);
+				$self->dic->logger->trace("multi-part match: $string");
+			} elsif ($string =~ m/^(\w+)\s+(\d+):(\d+)$/) {
+				($bookName, $chapterOrdinal, $verseOrdinalStart) = ($1, $2, $3);
+				$self->dic->logger->trace("single-part match: $string");
 			} else {
 				$self->dic->logger->error(sprintf('%s has been ignored because the format was not recognized', $key));
 			}
@@ -92,7 +94,9 @@ sub __makeRefs {
 			if ($bookName) {
 				my $verse;
 				$verseOrdinalEnd = $verseOrdinalStart if (!$verseOrdinalEnd || $verseOrdinalEnd > $verseOrdinalStart);
+				$self->dic->logger->trace(sprintf('Loop %d -> %d', $verseOrdinalStart, $verseOrdinalEnd));
 				for (my $verseOrdinal = $verseOrdinalStart; $verseOrdinal <= $verseOrdinalEnd; $verseOrdinal++) {
+					$self->dic->logger->trace(sprintf('Loop iteration %d', $verseOrdinal));
 					eval {
 						$verse = $self->dic->bible->fetch($bookName, $chapterOrdinal, $verseOrdinal);
 					};

--- a/lib/Religion/Bible/Verses/Exclusions.pm
+++ b/lib/Religion/Bible/Verses/Exclusions.pm
@@ -28,7 +28,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-package Religion::Bible::Verses::Exclusions; # TODO: Should it be under Config:: ?  But that's under DI, which is a problem, hmm
+package Religion::Bible::Verses::Exclusions;
 use strict;
 use warnings;
 use Moose;

--- a/lib/Religion/Bible/Verses/Exclusions.pm
+++ b/lib/Religion/Bible/Verses/Exclusions.pm
@@ -83,10 +83,8 @@ sub __makeRefs {
 			my ($bookName, $chapterOrdinal, $verseOrdinalStart, $verseOrdinalEnd);
 			if ($string =~ m/^(\w+)\s+(\d+):(\d+)-(\d+)$/) {
 				($bookName, $chapterOrdinal, $verseOrdinalStart, $verseOrdinalEnd) = ($1, $2, $3, $4);
-				$self->dic->logger->trace("multi-part match: $string");
 			} elsif ($string =~ m/^(\w+)\s+(\d+):(\d+)$/) {
 				($bookName, $chapterOrdinal, $verseOrdinalStart) = ($1, $2, $3);
-				$self->dic->logger->trace("single-part match: $string");
 			} else {
 				$self->dic->logger->error(sprintf('%s has been ignored because the format was not recognized', $key));
 			}
@@ -94,9 +92,7 @@ sub __makeRefs {
 			if ($bookName) {
 				my $verse;
 				$verseOrdinalEnd = $verseOrdinalStart if (!$verseOrdinalEnd || $verseOrdinalEnd < $verseOrdinalStart);
-				$self->dic->logger->trace(sprintf('Loop %d -> %d', $verseOrdinalStart, $verseOrdinalEnd));
 				for (my $verseOrdinal = $verseOrdinalStart; $verseOrdinal <= $verseOrdinalEnd; $verseOrdinal++) {
-					$self->dic->logger->trace(sprintf('Loop iteration %d', $verseOrdinal));
 					eval {
 						$verse = $self->dic->bible->fetch($bookName, $chapterOrdinal, $verseOrdinal);
 					};
@@ -127,7 +123,6 @@ sub __isExcludedRef {
 	foreach my $ref (@{ $self->refs }) {
 		if ($verse->equals($ref)) {
 			$excluded = 1;
-			$self->dic->logger->trace('VERSE REF MATCH! ' . $ref->toString());
 			last;
 		}
 	}
@@ -142,10 +137,7 @@ sub __isExcludedTerm {
 	foreach my $term (@{ $self->terms }) {
 		if (index($text, $term) > -1) {
 			$excluded = 1;
-			$self->dic->logger->trace("term '$term', text '$text': MATCH");
 			last;
-		} else {
-			$self->dic->logger->trace("term '$term', text '$text': MISMATCH");
 		}
 	}
 

--- a/lib/Religion/Bible/Verses/Server.pm
+++ b/lib/Religion/Bible/Verses/Server.pm
@@ -261,12 +261,14 @@ set serializer => 'JSON'; # or any other serializer
 
 get '/1/votd' => sub {
 	my $when = param('when');
-	return $server->__votd({ when => $when });
+	my $parental = int(param('parental'));
+	return $server->__votd({ when => $when, parental => $parental });
 };
 
 get '/2/votd' => sub {
 	my $when = param('when');
-	return $server->__votd({ version => 2, when => $when });
+	my $parental = int(param('parental'));
+	return $server->__votd({ version => 2, when => $when, parental => $parental });
 };
 
 get '/1/lookup/:book/:chapter/:verse' => sub {

--- a/lib/Religion/Bible/Verses/Verse.pm
+++ b/lib/Religion/Bible/Verses/Verse.pm
@@ -92,10 +92,7 @@ sub __makeContinues {
 
 sub __makeParental {
 	my ($self) = @_;
-	$self->dic->exclusions; # TODO
-	my $index = index($self->text, 'circumcised');
-	return 1 if ($index > -1);
-	return 0;
+	return $self->dic->exclusions->isExcluded($self);
 }
 
 sub getNext {

--- a/lib/Religion/Bible/Verses/Verse.pm
+++ b/lib/Religion/Bible/Verses/Verse.pm
@@ -54,6 +54,11 @@ has parental => (is => 'ro', isa => 'Str', lazy => 1, default => \&__makeParenta
 sub BUILD {
 }
 
+sub getNext {
+	my ($self) = @_;
+	return $self->chapter->getVerseByOrdinal($self->ordinal + 1);
+}
+
 sub toString {
 	my ($self, $verbose) = @_;
 	my $str = sprintf('%s:%d', $self->chapter->toString(), $self->ordinal);
@@ -93,11 +98,6 @@ sub __makeContinues {
 sub __makeParental {
 	my ($self) = @_;
 	return $self->dic->exclusions->isExcluded($self);
-}
-
-sub getNext {
-	my ($self) = @_;
-	return $self->chapter->getVerseByOrdinal($self->ordinal + 1);
 }
 
 1;

--- a/lib/Religion/Bible/Verses/Verse.pm
+++ b/lib/Religion/Bible/Verses/Verse.pm
@@ -47,6 +47,8 @@ has id => (is => 'ro', isa => 'Str', lazy => 1, default => \&__makeId);
 
 has continues => (is => 'ro', isa => 'Str', lazy => 1, default => \&__makeContinues);
 
+has parental => (is => 'ro', isa => 'Str', lazy => 1, default => \&__makeParental);
+
 sub BUILD {
 }
 
@@ -83,6 +85,13 @@ sub __makeContinues {
 		}
 	}
 
+	return 0;
+}
+
+sub __makeParental {
+	my ($self) = @_;
+	my $index = index($self->text, 'circumcised');
+	return 1 if ($index > -1);
 	return 0;
 }
 

--- a/lib/Religion/Bible/Verses/Verse.pm
+++ b/lib/Religion/Bible/Verses/Verse.pm
@@ -59,6 +59,11 @@ sub getNext {
 	return $self->chapter->getVerseByOrdinal($self->ordinal + 1);
 }
 
+sub equals {
+	my ($self, $other) = @_;
+	return ($self->id eq $other->id);
+}
+
 sub toString {
 	my ($self, $verbose) = @_;
 	my $str = sprintf('%s:%d', $self->chapter->toString(), $self->ordinal);

--- a/lib/Religion/Bible/Verses/Verse.pm
+++ b/lib/Religion/Bible/Verses/Verse.pm
@@ -33,6 +33,8 @@ use strict;
 use warnings;
 use Moose;
 
+extends 'Religion::Bible::Verses::Base';
+
 has book => (is => 'ro', isa => 'Religion::Bible::Verses::Book', required => 1);
 
 has chapter => (is => 'ro', isa => 'Religion::Bible::Verses::Chapter', required => 1);
@@ -90,6 +92,7 @@ sub __makeContinues {
 
 sub __makeParental {
 	my ($self) = @_;
+	$self->dic->exclusions; # TODO
 	my $index = index($self->text, 'circumcised');
 	return 1 if ($index > -1);
 	return 0;

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -21,6 +21,13 @@ paths:
             example: 2024-07-29T23:35:31+0100
           required: false
           description: Date in ISO-8601, for viewing previous verses of the day
+        - in: query
+          name: parental
+          schema:
+            type: boolean
+            default: false
+          required: false
+          description: Skip over verse if it is marked as sensitive in the server configuration file, and return the next alternative
       security: [] # No security
       responses:
         '200':
@@ -61,6 +68,13 @@ paths:
             example: 2024-07-29T23:35:31+0100
           required: false
           description: Date in ISO-8601, for viewing previous verses of the day
+        - in: query
+          name: parental
+          schema:
+            type: boolean
+            default: false
+          required: false
+          description: Skip over verse if it is marked as sensitive in the server configuration file, and return the next alternative
       security: [] # No security
       responses:
         '200':

--- a/t/Base.t
+++ b/t/Base.t
@@ -1,0 +1,83 @@
+#!/usr/bin/perl
+package BaseTests;
+use strict;
+use warnings;
+use Moose;
+
+use lib 'externals/libtest-module-runnable-perl/lib';
+
+extends 'Test::Module::Runnable';
+
+use English qw(-no_match_vars);
+use POSIX qw(EXIT_SUCCESS);
+use Religion::Bible::Verses::Base;
+use Test::Deep qw(cmp_deeply all isa methods bool re);
+use Test::Exception;
+use Test::More;
+
+sub setUp {
+	my ($self) = @_;
+
+	$self->sut(Religion::Bible::Verses::Base->new());
+
+	return EXIT_SUCCESS;
+}
+
+sub testDateString {
+	my ($self) = @_;
+	plan tests => 1;
+
+	my $str = '1810-09-14T12:00:00+0000';
+	cmp_deeply(
+		$self->sut->__resolveISO8601($str),
+		all(
+			isa('DateTime'),
+			methods(
+				year  => 1810,
+				month => 9,
+				day   => 14,
+			),
+		),
+	$str);
+
+	return EXIT_SUCCESS;
+}
+
+sub testDateObject {
+	my ($self) = @_;
+	plan tests => 1;
+
+	my $object = DateTime->new(year => 2011, month => 3, day => 5);
+	cmp_deeply(
+		$self->sut->__resolveISO8601($object),
+		all(
+			isa('DateTime'),
+			methods(
+				year  => 2011,
+				month => 3,
+				day   => 5,
+			),
+		),
+	'object');
+
+	return EXIT_SUCCESS;
+}
+
+sub testDefault {
+	my ($self) = @_;
+	plan tests => 1;
+
+	cmp_deeply(
+		$self->sut->__resolveISO8601(undef),
+		all(
+			isa('DateTime'),
+		),
+	'object');
+
+	return EXIT_SUCCESS;
+}
+
+package main;
+use strict;
+use warnings;
+exit(BaseTests->new->run);

--- a/t/Base.t
+++ b/t/Base.t
@@ -11,6 +11,7 @@ extends 'Test::Module::Runnable';
 use English qw(-no_match_vars);
 use POSIX qw(EXIT_SUCCESS);
 use Religion::Bible::Verses::Base;
+use Religion::Bible::Verses::DI::MockLogger;
 use Test::Deep qw(cmp_deeply all isa methods bool re);
 use Test::Exception;
 use Test::More;
@@ -19,6 +20,7 @@ sub setUp {
 	my ($self) = @_;
 
 	$self->sut(Religion::Bible::Verses::Base->new());
+	$self->__mockLogger();
 
 	return EXIT_SUCCESS;
 }
@@ -75,6 +77,12 @@ sub testDefault {
 	'object');
 
 	return EXIT_SUCCESS;
+}
+
+sub __mockLogger {
+	my ($self) = @_;
+	$self->sut->dic->logger(Religion::Bible::Verses::DI::MockLogger->new());
+	return;
 }
 
 package main;

--- a/t/Base.t
+++ b/t/Base.t
@@ -31,7 +31,7 @@ sub testDateString {
 
 	my $str = '1810-09-14T12:00:00+0000';
 	cmp_deeply(
-		$self->sut->__resolveISO8601($str),
+		$self->sut->_resolveISO8601($str),
 		all(
 			isa('DateTime'),
 			methods(
@@ -51,7 +51,7 @@ sub testDateObject {
 
 	my $object = DateTime->new(year => 2011, month => 3, day => 5);
 	cmp_deeply(
-		$self->sut->__resolveISO8601($object),
+		$self->sut->_resolveISO8601($object),
 		all(
 			isa('DateTime'),
 			methods(
@@ -70,11 +70,31 @@ sub testDefault {
 	plan tests => 1;
 
 	cmp_deeply(
-		$self->sut->__resolveISO8601(undef),
+		$self->sut->_resolveISO8601(undef),
 		all(
 			isa('DateTime'),
 		),
 	'object');
+
+	return EXIT_SUCCESS;
+}
+
+sub testMangledPlus {
+	my ($self) = @_;
+	plan tests => 1;
+
+	my $str = '1810-09-14T12:00:00 0000';
+	cmp_deeply(
+		$self->sut->_resolveISO8601($str),
+		all(
+			isa('DateTime'),
+			methods(
+				year  => 1810,
+				month => 9,
+				day   => 14,
+			),
+		),
+	$str);
 
 	return EXIT_SUCCESS;
 }

--- a/t/votd.t
+++ b/t/votd.t
@@ -118,11 +118,29 @@ sub testV2 {
 	return EXIT_SUCCESS;
 }
 
-sub testParental {
+sub testParentalTerm {
 	my ($self) = @_;
-	plan tests => 1;
+	plan tests => 2;
 
-	my $verse = $self->sut->votd({ version => 1, when => '1973-01-12T12:00:00+0100', parental => 1 });
+	my $when = '1973-01-12T12:00:00+0100';
+	my $verse = $self->sut->votd({ version => 1, when => $when, parental => 0 });
+	cmp_deeply($verse, all(
+		isa('Religion::Bible::Verses::Verse'),
+		methods(
+			book    => all(
+				isa('Religion::Bible::Verses::Book'),
+				methods(shortName => 'Gal'),
+			),
+			chapter => all(
+				isa('Religion::Bible::Verses::Chapter'),
+				methods(ordinal => 6),
+			),
+			ordinal => 12,
+			text    => ignore(),
+		),
+	), 'verse inspection') or diag(explain($verse->toString()));
+
+	$verse = $self->sut->votd({ version => 1, when => $when, parental => 1 });
 	cmp_deeply($verse, all(
 		isa('Religion::Bible::Verses::Verse'),
 		methods(
@@ -137,7 +155,49 @@ sub testParental {
 			ordinal => 10,
 			text    => ignore(),
 		),
+	), 'verse inspection, parental') or diag(explain($verse->toString()));
+
+	return EXIT_SUCCESS;
+}
+
+sub testParentalRef {
+	my ($self) = @_;
+	plan tests => 2;
+
+	my $when = '1810-09-14T12:00:00+0000';
+	my $verse = $self->sut->votd({ version => 1, when => $when, parental => 0 });
+	cmp_deeply($verse, all(
+		isa('Religion::Bible::Verses::Verse'),
+		methods(
+			book    => all(
+				isa('Religion::Bible::Verses::Book'),
+				methods(shortName => 'Judg'),
+			),
+			chapter => all(
+				isa('Religion::Bible::Verses::Chapter'),
+				methods(ordinal => 19),
+			),
+			ordinal => 25,
+			text    => ignore(),
+		),
 	), 'verse inspection') or diag(explain($verse->toString()));
+
+	$verse = $self->sut->votd({ version => 1, when => $when, parental => 1 });
+	cmp_deeply($verse, all(
+		isa('Religion::Bible::Verses::Verse'),
+		methods(
+			book    => all(
+				isa('Religion::Bible::Verses::Book'),
+				methods(shortName => '2Th'),
+			),
+			chapter => all(
+				isa('Religion::Bible::Verses::Chapter'),
+				methods(ordinal => 2),
+			),
+			ordinal => 17,
+			text    => ignore(),
+		),
+	), 'verse inspection, parental') or diag(explain($verse->toString()));
 
 	return EXIT_SUCCESS;
 }

--- a/t/votd.t
+++ b/t/votd.t
@@ -118,6 +118,30 @@ sub testV2 {
 	return EXIT_SUCCESS;
 }
 
+sub testParental {
+	my ($self) = @_;
+	plan tests => 1;
+
+	my $verse = $self->sut->votd({ version => 1, when => '1973-01-12T12:00:00+0100', parental => 1 });
+	cmp_deeply($verse, all(
+		isa('Religion::Bible::Verses::Verse'),
+		methods(
+			book    => all(
+				isa('Religion::Bible::Verses::Book'),
+				methods(shortName => 'Jonah'),
+			),
+			chapter => all(
+				isa('Religion::Bible::Verses::Chapter'),
+				methods(ordinal => 4),
+			),
+			ordinal => 10,
+			text    => ignore(),
+		),
+	), 'verse inspection') or diag(explain($verse->toString()));
+
+	return EXIT_SUCCESS;
+}
+
 sub __mockLogger {
 	my ($self) = @_;
 	$self->sut->dic->logger(Religion::Bible::Verses::DI::MockLogger->new());


### PR DESCRIPTION
Allow references to be registered as sensitive and a parental mode can then exclude them for Verses of The Day (only).

- Terms, such as words can be excluded
- References and ranges of references, such as Judges 19:22-29 can be excluded
- log via diag() in test framework when TEST_VERBOSE is set
- added error() in the mock logger
- Move location of getNext() method
- fix bad client behavior with '+' handling