### PR TITLE
hires timer stats

### DIFF
--- a/lib/Religion/Bible/Verses.pm
+++ b/lib/Religion/Bible/Verses.pm
@@ -38,6 +38,7 @@ extends 'Religion::Bible::Verses::Base';
 use Data::Dumper;
 use Digest::CRC qw(crc32);
 use Scalar::Util qw(looks_like_number);
+use Time::HiRes ();
 
 use Religion::Bible::Verses::Backend;
 use Religion::Bible::Verses::DI::Container;
@@ -148,6 +149,7 @@ sub fetch {
 
 sub votd {
 	my ($self, $params) = @_;
+	my $startTiming = Time::HiRes::time();
 	my ($when, $version, $parental) = @{$params}{qw(when version parental)};
 
 	$when = $self->_resolveISO8601($when);
@@ -181,6 +183,10 @@ sub votd {
 			push(@$verse, $verse->[-1]->getNext());
 		}
 	}
+
+	my $endTiming = Time::HiRes::time();
+	my $d = int(1000 * ($endTiming - $startTiming));
+	$self->dic->logger->debug(sprintf('VoTD sought in %dms', $d));
 
 	return $verse;
 }

--- a/lib/Religion/Bible/Verses.pm
+++ b/lib/Religion/Bible/Verses.pm
@@ -137,12 +137,15 @@ sub resolveBook {
 
 sub fetch {
 	my ($self, $book, $chapterOrdinal, $verseOrdinal) = @_;
+	my $startTiming = Time::HiRes::time();
 
 	$book = $self->resolveBook($book);
 	my $chapter = $book->getChapterByOrdinal($chapterOrdinal);
 	my $verse = $chapter->getVerseByOrdinal($verseOrdinal);
 
-	$self->dic->logger->debug($verse->toString());
+	my $endTiming = Time::HiRes::time();
+	my $d = int(1000 * ($endTiming - $startTiming));
+	$self->dic->logger->debug(sprintf('%s sought in %dms', $verse->toString(), $d));
 
 	return $verse;
 }

--- a/lib/Religion/Bible/Verses/Search/Query.pm
+++ b/lib/Religion/Bible/Verses/Search/Query.pm
@@ -94,8 +94,9 @@ sub run {
 	});
 
 	my $endTiming = Time::HiRes::time();
-	my $d = int(1000 * ($endTiming - $startTiming));
-	$self->dic->logger->debug(sprintf("Ran search %s and received %s in %dms", $self->toString(), $results->toString(), $d));
+	my $msec = int(1000 * ($endTiming - $startTiming));
+	$results->msec($msec);
+	$self->dic->logger->debug(sprintf("Ran search %s and received %s in %dms", $self->toString(), $results->toString(), $msec));
 
 	return $results;
 }

--- a/lib/Religion/Bible/Verses/Search/Query.pm
+++ b/lib/Religion/Bible/Verses/Search/Query.pm
@@ -38,6 +38,7 @@ extends 'Religion::Bible::Verses::Base';
 use Data::Dumper;
 use Moose::Util::TypeConstraints qw(enum);
 use Religion::Bible::Verses::Search::Results;
+use Time::HiRes ();
 
 has _library => (is => 'ro', isa => 'Religion::Bible::Verses', required => 1);
 
@@ -68,6 +69,7 @@ sub setWholeword {
 
 sub run {
 	my ($self) = @_;
+	my $startTiming = Time::HiRes::time();
 
 	my @booksToQuery = ( );
 	if ($self->bookShortName) {
@@ -91,7 +93,9 @@ sub run {
 		verses => \@verses,
 	});
 
-	$self->dic->logger->debug(sprintf("Ran search %s and received %s", $self->toString(), $results->toString()));
+	my $endTiming = Time::HiRes::time();
+	my $d = int(1000 * ($endTiming - $startTiming));
+	$self->dic->logger->debug(sprintf("Ran search %s and received %s in %dms", $self->toString(), $results->toString(), $d));
 
 	return $results;
 }

--- a/lib/Religion/Bible/Verses/Search/Results.pm
+++ b/lib/Religion/Bible/Verses/Search/Results.pm
@@ -39,6 +39,8 @@ has query => (is => 'ro', isa => 'Religion::Bible::Verses::Search::Query', requi
 
 has verses => (is => 'ro', isa => 'ArrayRef[Religion::Bible::Verses::Verse]', required => 1);
 
+has msec => (is => 'rw', isa => 'Int', default => 0);
+
 sub BUILD {
 }
 

--- a/lib/Religion/Bible/Verses/Server.pm
+++ b/lib/Religion/Bible/Verses/Server.pm
@@ -236,14 +236,24 @@ sub __search {
 		});
 	}
 
-	push(@{ $hash{included} }, {
-		type => 'results_summary',
-		id => uuid_to_string(create_uuid()),
-		attributes => {
-			count => $results->count,
+	push(@{ $hash{included} },
+		{
+			type => 'results_summary',
+			id => uuid_to_string(create_uuid()),
+			attributes => {
+				count => $results->count,
+			},
+			links => { },
 		},
-		links => { },
-	});
+		{
+			type => 'stats',
+			id => uuid_to_string(create_uuid()),
+			attributes => {
+				msec => int($results->msec),
+			},
+			links => { },
+		},
+	);
 
 	return \%hash;
 }

--- a/lib/Religion/Bible/Verses/Server.pm
+++ b/lib/Religion/Bible/Verses/Server.pm
@@ -110,6 +110,16 @@ sub __verseToJsonApi {
 		relationships => { },
 	});
 
+	my $dic = Religion::Bible::Verses::DI::Container->instance;
+	push(@{ $hash{included} }, {
+		type => 'stats',
+		id => uuid_to_string(create_uuid()),
+		attributes => {
+			msec => int($verse->msec),
+		},
+		links => { },
+	});
+
 	push(@{ $hash{data} }, {
 		type => $verse->type,
 		id => $verse->id,
@@ -163,8 +173,19 @@ sub __votd {
 			push(@json, __verseToJsonApi($verse->[$verseI]));
 		}
 
+		my $secondary_total_msec = 0;
 		for (my $verseI = 1; $verseI < scalar(@$verse); $verseI++) {
 			push(@{ $json[0]->{data} },  $json[$verseI]->{data}->[0]);
+			for (my $includedI = 0; $includedI < scalar(@{ $json[$verseI]->{included} }); $includedI++) {
+				my $inclusion = $json[$verseI]->{included}->[$includedI];
+				next if ($inclusion->{type} ne 'stats');
+				$secondary_total_msec += $inclusion->{attributes}->{msec};
+			}
+		}
+
+		for (my $includedI = 0; $includedI < scalar(@{ $json[0]->{included} }); $includedI++) {
+			next if ($json[0]->{included}->[$includedI]->{type} ne 'stats');
+			$json[0]->{included}->[$includedI]->{attributes}->{msec} += $secondary_total_msec;
 		}
 
 		return $json[0];

--- a/lib/Religion/Bible/Verses/Verse.pm
+++ b/lib/Religion/Bible/Verses/Verse.pm
@@ -45,6 +45,8 @@ has text => (is => 'ro', isa => 'Str', required => 1);
 
 has type => (is => 'ro', isa => 'Str', default => sub { 'verse' });
 
+has msec => (is => 'rw', isa => 'Int', default => 0);
+
 has id => (is => 'ro', isa => 'Str', lazy => 1, default => \&__makeId);
 
 has continues => (is => 'ro', isa => 'Str', lazy => 1, default => \&__makeContinues);

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -43,7 +43,8 @@ paths:
                       $ref: '#/components/schemas/Verse'
                   included:
                     type: array
-                    items: {}
+                    items:
+                      $ref: '#/components/schemas/Stats'
         '429':
           description: Rate-limited
         '500':
@@ -90,7 +91,8 @@ paths:
                       $ref: '#/components/schemas/Verse'
                   included:
                     type: array
-                    items: {}
+                    items:
+                      $ref: '#/components/schemas/Stats'
         '429':
           description: Rate-limited
         '500':
@@ -142,7 +144,8 @@ paths:
                       $ref: '#/components/schemas/Verse'
                   included:
                     type: array
-                    items: {}
+                    items:
+                      $ref: '#/components/schemas/Stats'
         '400':
           description: Bad request
         '429':
@@ -196,7 +199,8 @@ paths:
                       $ref: '#/components/schemas/Verse'
                   included:
                     type: array
-                    items: {}
+                    items:
+                      $ref: '#/components/schemas/Stats'
         '400':
           description: Bad request
         '404':
@@ -240,3 +244,15 @@ components:
               type: string
               description: Verbatim and unedited text from the Holy Bible.
               example: Thus did Noah; according to all that God commanded him, so did he.
+    Stats:
+      type: object
+      properties:
+        id:
+          type: string
+        attributes:
+          type: object
+          properties:
+            msec:
+              type: integer
+              description: ms for core request resolution, without overhead, for debugging core algorithm degredation and loading only
+              example: 189

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -254,5 +254,5 @@ components:
           properties:
             msec:
               type: integer
-              description: ms for core request resolution, without overhead, for debugging core algorithm degredation and loading only
+              description: ms for core request resolution, without overhead, for debugging core algorithm degradation and loading only
               example: 189

--- a/t/Server_votd.t
+++ b/t/Server_votd.t
@@ -118,6 +118,14 @@ sub test {
 				relationships => {},
 				type => 'book'
 			},
+			{
+				attributes => {
+					msec => re(qr/^\d+$/),
+				},
+				id => ignore(), # uuid
+				type => 'stats',
+				links => {},
+			},
 		],
 		links => {},
 	}, "single verse JSON for $when") or diag(explain($json));
@@ -275,6 +283,14 @@ sub testV2 {
 				id => 'Titus',
 				relationships => {},
 				type => 'book'
+			},
+			{
+				attributes => {
+					msec => re(qr/^\d+$/),
+				},
+				id => ignore(), # uuid
+				type => 'stats',
+				links => {},
 			},
 		],
 		links => {},


### PR DESCRIPTION
These stats are sometimes '0' ms but this may be due to Perl optimizations, and quite often, especially with searches, we show that most searches are fulfilled within less than a second.  This is good news for the project and will help to protect against regressions.