### PR TITLE
HTML for VoTD

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -29,6 +29,8 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
+image: atlassian/default-image:4
+
 pipelines:
   default:
     - step:

--- a/lib/Chleb/Args/Base.pm
+++ b/lib/Chleb/Args/Base.pm
@@ -28,11 +28,11 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-package Chleb::Server::MediaType::Args::ToString;
+package Chleb::Args::Base;
 use strict;
 use warnings;
 use Moose;
 
-extends 'Chleb::Args::Base';
+has verbose => (is => 'ro', isa => 'Bool', default => 0);
 
 1;

--- a/lib/Chleb/Args/Base.pm
+++ b/lib/Chleb/Args/Base.pm
@@ -33,6 +33,14 @@ use strict;
 use warnings;
 use Moose;
 
+use Chleb::Server::MediaType::Args::ToString;
+
 has verbose => (is => 'ro', isa => 'Bool', default => 0);
+
+sub makeDummy {
+	my ($class, $args) = @_; # TODO; ignored $class
+	return $args if ($args); # shortcut
+	return Chleb::Server::MediaType::Args::ToString->new();
+}
 
 1;

--- a/lib/Chleb/Args/Base.pm
+++ b/lib/Chleb/Args/Base.pm
@@ -38,9 +38,12 @@ use Chleb::Server::MediaType::Args::ToString;
 has verbose => (is => 'ro', isa => 'Bool', default => 0);
 
 sub makeDummy {
-	my ($class, $args) = @_; # TODO; ignored $class
-	return $args if ($args); # shortcut
-	return Chleb::Server::MediaType::Args::ToString->new();
+	my ($class, $args) = @_;
+	if ($args) {
+		return $args if ($args->isa($class));
+		die('$args must be of type ' . $class);
+	}
+	return $class->new();
 }
 
 1;

--- a/lib/Chleb/Server.pm
+++ b/lib/Chleb/Server.pm
@@ -265,33 +265,25 @@ sub __votd {
 	my $contentType = $CONTENT_TYPE_TEXT;
 	if (my $accept = $params->{accept}) {
 		my $items = $accept->items;
-		my %userPriorities = (
+		my %priorities = (
 			# defaults
 			'text/plain' => 0,
 			'text/html' => 0,
 			'*/*' => 0,
 			'application/json' => 1,
 		);
-		for (my $priority = 0; $priority < scalar(@$items); $priority++) {
-			my $item = $items->[$priority];
-			my $recordPriority = 0;
 
-			if ($item->major eq '*') {
-				$recordPriority = 1;
-			} elsif ($item->major eq 'text' || ($item->minor eq 'plain' && $item->minor eq 'html')) {
-				$recordPriority = 1;
-			} elsif ($item->major eq 'application' && $item->minor eq 'json') {
-				$recordPriority = 1;
-			}
+		my $userPriorityMap = $accept->getPriorityMap();
+		while (my ($k, $v) = each(%$userPriorityMap)) {
+			$priorities{$k} = $v;
 		}
 
 		# nb. lower-priorities are higher, so the logic reads backward
-		# TODO: Should probably have a priorityFromItem, or prioritiesFromIndex?  Would elimiate loop above at least
-		if ($userPriorities{'application/json'} < $userPriorities{'*/*'}) {
+		if ($priorities{'application/json'} <= $priorities{'*/*'}) {
 			$contentType = $CONTENT_TYPE_JSON;
-		} elsif ($userPriorities{'application/json'} < $userPriorities{'text/plain'}) {
+		} elsif ($priorities{'application/json'} <= $priorities{'text/plain'}) {
 			$contentType = $CONTENT_TYPE_JSON;
-		} elsif ($userPriorities{'application/json'} < $userPriorities{'text/html'}) {
+		} elsif ($priorities{'application/json'} <= $priorities{'text/html'}) {
 			$contentType = $CONTENT_TYPE_JSON;
 		}
 	}

--- a/lib/Chleb/Server.pm
+++ b/lib/Chleb/Server.pm
@@ -745,7 +745,7 @@ get '/2/votd' => sub {
 		handleException($exception);
 	}
 
-	if ($mediaType->items->[0]->major eq 'text') {
+	if (ref($result) ne 'HASH') {
 		send_as html => $result;
 	}
 

--- a/lib/Chleb/Server.pm
+++ b/lib/Chleb/Server.pm
@@ -261,7 +261,7 @@ sub __votd {
 	my $version = $params->{version} || 1;
 	my $redirect = $params->{redirect} // 0;
 
-	my $contentType = Chleb::Server::MediaType::acceptToContentType($params, $CONTENT_TYPE_DEFAULT);
+	my $contentType = Chleb::Server::MediaType::acceptToContentType($params->{accept}, $CONTENT_TYPE_DEFAULT);
 
 	die Chleb::Exception->raise(HTTP_BAD_REQUEST, 'votd redirect is only supported on version 1')
 	    if ($redirect && $version > 1);

--- a/lib/Chleb/Server.pm
+++ b/lib/Chleb/Server.pm
@@ -292,7 +292,7 @@ sub __votd {
 		$json[0]->{links}->{self} =  '/' . join('/', $version, 'votd') . Chleb::Utils::queryParamsHelper($params);
 		return $json[0] if ($contentType eq $Chleb::Server::MediaType::CONTENT_TYPE_JSON); # application/json
 
-		if ($contentType eq $Chleb::Server::MediaType::CONTENT_TYPE_HTML) { # text/plain
+		if ($contentType eq $Chleb::Server::MediaType::CONTENT_TYPE_HTML) { # text/html
 			# TODO: This can't handle continuation of more than one verse, and should probably be in a sub
 			my $translation = 'unknown'; # FIXME: Where is it in the JSON?
 			my $attributes = $json[0]->{data}->[0]->{attributes};

--- a/lib/Chleb/Server.pm
+++ b/lib/Chleb/Server.pm
@@ -270,7 +270,7 @@ sub __votd {
 			'text/plain' => 0,
 			'text/html' => 0,
 			'*/*' => 0,
-			$CONTENT_TYPE_JSON => 1,
+			$CONTENT_TYPE_JSON => 9_999_999, # lowest priority
 		);
 
 		my $userPriorityMap = $accept->getPriorityMap();
@@ -281,9 +281,11 @@ sub __votd {
 		# nb. lower-priorities are higher, so the logic reads backward
 		if ($priorities{$CONTENT_TYPE_JSON} <= $priorities{'*/*'}) {
 			$contentType = $CONTENT_TYPE_JSON;
-		} elsif ($priorities{$CONTENT_TYPE_JSON} <= $priorities{'text/plain'}) {
+		}
+		if ($priorities{$CONTENT_TYPE_JSON} <= $priorities{'text/plain'}) {
 			$contentType = $CONTENT_TYPE_JSON;
-		} elsif ($priorities{$CONTENT_TYPE_JSON} <= $priorities{'text/html'}) {
+		}
+		if ($priorities{$CONTENT_TYPE_JSON} <= $priorities{'text/html'}) {
 			$contentType = $CONTENT_TYPE_JSON;
 		}
 	}

--- a/lib/Chleb/Server.pm
+++ b/lib/Chleb/Server.pm
@@ -634,6 +634,7 @@ use Scalar::Util qw(blessed);
 my $server;
 
 set serializer => 'JSON'; # or any other serializer
+set content_type => 'application/json';
 
 sub handleException {
 	my ($exception) = @_;
@@ -713,6 +714,10 @@ get '/2/votd' => sub {
 
 	if (my $exception = $EVAL_ERROR) {
 		handleException($exception);
+	}
+
+	if ($accept ne 'application/json') {
+		send_as html => $result;
 	}
 
 	return $result;

--- a/lib/Chleb/Server.pm
+++ b/lib/Chleb/Server.pm
@@ -315,7 +315,7 @@ sub __votd {
 			if ($verseCount == 1) {
 				$output .= sprintf(" [%s]\r\n", $translation);
 			} else {
-				$output .= sprintf("\r\n\t(%s)\r\n", $translation);
+				$output .= sprintf("\r\n\r\n\t(%s)\r\n", $translation);
 			}
 
 			return $output;

--- a/lib/Chleb/Server.pm
+++ b/lib/Chleb/Server.pm
@@ -265,7 +265,12 @@ sub __votd {
 
 	my $version = $params->{version} || 1;
 	my $redirect = $params->{redirect} // 0;
-	my $contentType = $params->{contentType} // $CONTENT_TYPE_JSON;
+	my $contentType = $params->{contentType};
+	if (!$contentType) {
+		$contentType = $CONTENT_TYPE_JSON;
+	} elsif ($contentType eq '*/*') {
+		$contentType = $CONTENT_TYPE_JSON;
+	}
 
 	die Chleb::Exception->raise(HTTP_BAD_REQUEST, 'votd redirect is only supported on version 1')
 	    if ($redirect && $version > 1);

--- a/lib/Chleb/Server.pm
+++ b/lib/Chleb/Server.pm
@@ -294,14 +294,13 @@ sub __votd {
 
 		if ($contentType eq $Chleb::Server::MediaType::CONTENT_TYPE_HTML) { # text/html
 			# TODO: This can't handle continuation of more than one verse, and should probably be in a sub
-			my $translation = 'unknown'; # FIXME: Where is it in the JSON?
 			my $attributes = $json[0]->{data}->[0]->{attributes};
 			return sprintf("%s %d:%d %s [%s]\r\n",
 				$attributes->{book},
 				$attributes->{chapter},
 				$attributes->{ordinal},
 				$attributes->{text},
-				$translation,
+				$attributes->{translation},
 			);
 		} else {
 			die Chleb::Exception->raise(HTTP_NOT_ACCEPTABLE, "Only $Chleb::Server::MediaType::CONTENT_TYPE_HTML is supported");

--- a/lib/Chleb/Server.pm
+++ b/lib/Chleb/Server.pm
@@ -293,32 +293,7 @@ sub __votd {
 		return $json[0] if ($contentType eq $Chleb::Server::MediaType::CONTENT_TYPE_JSON); # application/json
 
 		if ($contentType eq $Chleb::Server::MediaType::CONTENT_TYPE_HTML) { # text/html
-			# TODO: This should probably be in a sub
-			my $output = '';
-			my $verseCount = scalar(@{ $json[0]->{data} });
-			for (my $verseIndex = 0; $verseIndex < $verseCount; $verseIndex++) {
-				my $attributes = $json[0]->{data}->[$verseIndex]->{attributes};
-				$output .= sprintf('%s %d:%d %s',
-					$attributes->{book},
-					$attributes->{chapter},
-					$attributes->{ordinal},
-					$attributes->{text},
-				);
-
-				if ($verseIndex < $verseCount-1) { # not last verse
-					$output .= "\r\n";
-				}
-			}
-
-			my $translation = $json[0]->{data}->[0]->{attributes}->{translation};
-
-			if ($verseCount == 1) {
-				$output .= sprintf(" [%s]\r\n", $translation);
-			} else {
-				$output .= sprintf("\r\n\r\n\t(%s)\r\n", $translation);
-			}
-
-			return $output;
+			return __verseToHtml(\@json);
 		} else {
 			die Chleb::Exception->raise(HTTP_NOT_ACCEPTABLE, "Only $Chleb::Server::MediaType::CONTENT_TYPE_HTML is supported");
 		}
@@ -635,6 +610,36 @@ sub __verseToJsonApi {
 	});
 
 	return \%hash;
+}
+
+sub __verseToHtml {
+	my ($json) = @_;
+
+	my $output = '';
+	my $verseCount = scalar(@{ $json->[0]->{data} });
+	for (my $verseIndex = 0; $verseIndex < $verseCount; $verseIndex++) {
+		my $attributes = $json->[0]->{data}->[$verseIndex]->{attributes};
+		$output .= sprintf('%s %d:%d %s',
+			$attributes->{book},
+			$attributes->{chapter},
+			$attributes->{ordinal},
+			$attributes->{text},
+		);
+
+		if ($verseIndex < $verseCount-1) { # not last verse
+			$output .= "\r\n";
+		}
+	}
+
+	my $translation = $json->[0]->{data}->[0]->{attributes}->{translation};
+
+	if ($verseCount == 1) {
+		$output .= sprintf(" [%s]\r\n", $translation);
+	} else {
+		$output .= sprintf("\r\n\r\n\t(%s)\r\n", $translation);
+	}
+
+	return $output;
 }
 
 =back

--- a/lib/Chleb/Server.pm
+++ b/lib/Chleb/Server.pm
@@ -317,8 +317,7 @@ sub __votd {
 		$json[0]->{links}->{self} =  '/' . join('/', $version, 'votd') . Chleb::Utils::queryParamsHelper($params);
 		return $json[0] if ($contentType eq $CONTENT_TYPE_JSON); # application/json
 
-		if ($contentType eq $CONTENT_TYPE_TEXT) {
-			# text/plain
+		if ($contentType eq $CONTENT_TYPE_TEXT) { # text/plain
 			# TODO: This can't handle continuation of more than one verse, and should probably be in a sub
 			my $translation = 'unknown'; # FIXME: Where is it in the JSON?
 			my $attributes = $json[0]->{data}->[0]->{attributes};

--- a/lib/Chleb/Server.pm
+++ b/lib/Chleb/Server.pm
@@ -46,6 +46,7 @@ Dancer2 server for stand-alone HTTP server for Chleb Bible Search
 use Chleb;
 use Chleb::Exception;
 use Chleb::DI::Container;
+use Chleb::Server::MediaType;
 use Chleb::Utils;
 use HTTP::Status qw(:constants);
 use JSON;
@@ -711,7 +712,8 @@ get '/2/votd' => sub {
 	my $when = param('when');
 	my $dancerRequest = request();
 
-	my $accept = $dancerRequest->header('Accept');
+	my $mediaType = Chleb::Server::MediaType->parseAcceptHeader($dancerRequest->header('Accept'));
+	my $accept = $mediaType->items->[0]->toString();
 
 	my $result;
 	eval {

--- a/lib/Chleb/Server.pm
+++ b/lib/Chleb/Server.pm
@@ -296,11 +296,11 @@ sub __votd {
 			# TODO: This can't handle continuation of more than one verse, and should probably be in a sub
 			my $translation = 'unknown'; # FIXME: Where is it in the JSON?
 			my $attributes = $json[0]->{data}->[0]->{attributes};
-			return sprintf("%s\r\n\r\n%s %d:%d (%s)\r\n",
-				$attributes->{text},
+			return sprintf("%s %d:%d %s [%s]\r\n",
 				$attributes->{book},
 				$attributes->{chapter},
 				$attributes->{ordinal},
+				$attributes->{text},
 				$translation,
 			);
 		} else {

--- a/lib/Chleb/Server.pm
+++ b/lib/Chleb/Server.pm
@@ -656,7 +656,7 @@ package main;
 use strict;
 use warnings;
 
-use Dancer2;
+use Dancer2 0.2;
 use English qw(-no_match_vars);
 use HTTP::Status qw(:is);
 use POSIX qw(EXIT_SUCCESS);

--- a/lib/Chleb/Server.pm
+++ b/lib/Chleb/Server.pm
@@ -270,7 +270,7 @@ sub __votd {
 			'text/plain' => 0,
 			'text/html' => 0,
 			'*/*' => 0,
-			'application/json' => 1,
+			$CONTENT_TYPE_JSON => 1,
 		);
 
 		my $userPriorityMap = $accept->getPriorityMap();
@@ -279,11 +279,11 @@ sub __votd {
 		}
 
 		# nb. lower-priorities are higher, so the logic reads backward
-		if ($priorities{'application/json'} <= $priorities{'*/*'}) {
+		if ($priorities{$CONTENT_TYPE_JSON} <= $priorities{'*/*'}) {
 			$contentType = $CONTENT_TYPE_JSON;
-		} elsif ($priorities{'application/json'} <= $priorities{'text/plain'}) {
+		} elsif ($priorities{$CONTENT_TYPE_JSON} <= $priorities{'text/plain'}) {
 			$contentType = $CONTENT_TYPE_JSON;
-		} elsif ($priorities{'application/json'} <= $priorities{'text/html'}) {
+		} elsif ($priorities{$CONTENT_TYPE_JSON} <= $priorities{'text/html'}) {
 			$contentType = $CONTENT_TYPE_JSON;
 		}
 	}

--- a/lib/Chleb/Server.pm
+++ b/lib/Chleb/Server.pm
@@ -745,9 +745,11 @@ get '/2/votd' => sub {
 	}
 
 	if (ref($result) ne 'HASH') {
+		$server->dic->logger->trace('2/votd returned as HTML');
 		send_as html => $result;
 	}
 
+	$server->dic->logger->trace('2/votd returned as JSON');
 	return $result;
 };
 

--- a/lib/Chleb/Server.pm
+++ b/lib/Chleb/Server.pm
@@ -724,10 +724,8 @@ get '/2/votd' => sub {
 		handleException($exception);
 	}
 
-	if ($accept eq $Chleb::Server::CONTENT_TYPE_HTML) {
+	if ($accept eq $Chleb::Server::CONTENT_TYPE_HTML || $accept eq $Chleb::Server::CONTENT_TYPE_TEXT) {
 		send_as html => $result;
-	} elsif ($accept eq $Chleb::Server::CONTENT_TYPE_TEXT) {
-		send_as text => $result;
 	}
 
 	return $result;

--- a/lib/Chleb/Server/MediaType.pm
+++ b/lib/Chleb/Server/MediaType.pm
@@ -100,7 +100,7 @@ sub parseAcceptHeader {
 	if (!defined($str) || length($str) < $MINIMUM_LENGTH) {
 		# invalid header under minimum length is not something worth handling, pretend it was valid and */*
 		$str = $DEFAULT_HEADER;
-		$dic->logger->warn('Accept header was bad, substituting default wildcard');
+		$dic->logger->trace('Short Accept header, substituting default wildcard');
 	} else {
 		$dic->logger->trace("Accept header: '$str'");
 	}
@@ -208,7 +208,14 @@ Return a human-readable string for logging purposes
 
 sub toString {
 	my ($self) = @_;
-	return $self->original;
+
+	my $str = $self->original . "\n";
+	for (my $priority = 0; $priority < scalar(@{ $self->items }); $priority++) {
+		my $item = $self->items->[$priority];
+		$str .= sprintf("[%d] %s;q=%.1f\n", $priority, $item->toString(), $item->weight);
+	}
+
+	return $str;
 }
 
 =back

--- a/lib/Chleb/Server/MediaType.pm
+++ b/lib/Chleb/Server/MediaType.pm
@@ -149,7 +149,7 @@ sub parseAcceptHeader {
 		original => $str,
 	});
 
-	$dic->logger->trace('Created MediaType object: ' . $object->toString());
+	$dic->logger->trace('Created MediaType object: ' . $object->toString({ verbose => 1 }));
 	return $object;
 }
 
@@ -200,19 +200,34 @@ sub getWeightMap {
 	return \%weightMap;
 }
 
-=item C<toString()>
+=item C<toString([$args])>
 
 Return a human-readable string for logging purposes
+
+The C<$args HASH> may contain the following keys:
+
+=over
+
+=item C<verbose>
+
+True of false, default false, indicating whether we call toString() on L</items>.
+
+=back
 
 =cut
 
 sub toString {
-	my ($self) = @_;
+	my ($self, $args) = @_;
+	my ($verbose) = @{$args}{qw(verbose)};
 
-	my $str = $self->original . "\n";
-	for (my $priority = 0; $priority < scalar(@{ $self->items }); $priority++) {
-		my $item = $self->items->[$priority];
-		$str .= sprintf("[%d] %s;q=%.1f\n", $priority, $item->toString(), $item->weight);
+	my $str = $self->original;
+	if ($verbose) {
+		$str .= "\n";
+
+		for (my $priority = 0; $priority < scalar(@{ $self->items }); $priority++) {
+			my $item = $self->items->[$priority];
+			$str .= sprintf("[%d] %s;q=%.1f\n", $priority, $item->toString(), $item->weight);
+		}
 	}
 
 	return $str;

--- a/lib/Chleb/Server/MediaType.pm
+++ b/lib/Chleb/Server/MediaType.pm
@@ -94,14 +94,16 @@ but L<HTTP::Headers> is also accepted, and we'll process the right header.
 sub parseAcceptHeader {
 	my ($class, $str) = @_;
 
+	my $dic = Chleb::DI::Container->instance;
+
 	$str = __resolveObject($str);
 	if (!defined($str) || length($str) < $MINIMUM_LENGTH) {
 		# invalid header under minimum length is not something worth handling, pretend it was valid and */*
 		$str = $DEFAULT_HEADER;
+		$dic->logger->warn('Accept header was bad, substituting default wildcard');
+	} else {
+		$dic->logger->trace("Accept header: '$str'");
 	}
-
-	my $dic = Chleb::DI::Container->instance;
-	$dic->logger->trace("Accept header: '$str'");
 
 	$str =~ s/\s+//g; # remove all whitespace
 	my @types = split(m@,@, lc($str));

--- a/lib/Chleb/Server/MediaType.pm
+++ b/lib/Chleb/Server/MediaType.pm
@@ -226,7 +226,8 @@ sub toString {
 
 		for (my $priority = 0; $priority < scalar(@{ $self->items }); $priority++) {
 			my $item = $self->items->[$priority];
-			$str .= sprintf("[%d] %s;q=%.1f\n", $priority, $item->toString(), $item->weight);
+			$str .= sprintf('[%d] %s', $priority, $item->toString($args));
+			$str .= "\n";
 		}
 	}
 

--- a/lib/Chleb/Server/MediaType.pm
+++ b/lib/Chleb/Server/MediaType.pm
@@ -160,53 +160,6 @@ sub parseAcceptHeader {
 	return $object;
 }
 
-=item C<priorityFromTypeStr($typeStr)>
-
-=cut
-
-sub priorityFromTypeStr {
-	my ($self, $typeStr) = @_;
-
-	for (my $priority = 0; $priority < scalar(@{ $self->items }); $priority++) {
-		my $item = $self->items->[$priority];
-		return $priority if ($item->toString() eq $typeStr);
-	}
-
-	#return -1;
-	return 9_999_999; # lowest priority
-}
-
-=item C<getPriorityMap()>
-
-=cut
-
-sub getPriorityMap {
-	my ($self) = @_;
-
-	my %priorityMap = ( );
-	for (my $priority = 0; $priority < scalar(@{ $self->items }); $priority++) { # decreasing priorities
-		my $item = $self->items->[$priority];
-		$priorityMap{ $item->toString() } = $priority;
-	}
-
-	return \%priorityMap;
-}
-
-=item C<getWeightMap()>
-
-=cut
-
-sub getWeightMap {
-	my ($self) = @_;
-
-	my %weightMap = ( );
-	foreach my $item (@{ $self->items }) {
-		$weightMap{ $item->toString() } = $item->weight;
-	}
-
-	return \%weightMap;
-}
-
 =item C<acceptToContentType($params, $default)>
 
 =cut

--- a/lib/Chleb/Server/MediaType.pm
+++ b/lib/Chleb/Server/MediaType.pm
@@ -97,7 +97,7 @@ sub parseAcceptHeader {
 	if (!defined($str) || length($str) == 0) {
 		$str = $DEFAULT_HEADER;
 	} elsif (length($str) < $MINIMUM_LENGTH) {
-		die Chleb::Exception->raise(HTTP_NOT_ACCEPTABLE, 'Accept: header too short');
+		die Chleb::Exception->raise(HTTP_NOT_ACCEPTABLE, 'Accept: header too short'); # FIXME: '*' is apparently a valid Accept header
 	}
 
 	$str =~ s/\s+//g; # remove all whitespace

--- a/lib/Chleb/Server/MediaType.pm
+++ b/lib/Chleb/Server/MediaType.pm
@@ -212,11 +212,11 @@ sub getWeightMap {
 =cut
 
 sub acceptToContentType {
-	my ($params, $default) = @_;
+	my ($accept, $default) = @_;
 
 	my $contentType = $default;
 
-	if (my $accept = $params->{accept}) {
+	if ($accept) {
 		foreach my $item (reverse(@{ $accept->items })) {
 			if ($item->major eq 'text') {
 				if ($item->minor eq 'html' || $item->minor eq '*') {

--- a/lib/Chleb/Server/MediaType.pm
+++ b/lib/Chleb/Server/MediaType.pm
@@ -227,7 +227,7 @@ sub toString {
 		for (my $priority = 0; $priority < scalar(@{ $self->items }); $priority++) {
 			my $item = $self->items->[$priority];
 			$str .= sprintf('[%d] %s', $priority, $item->toString($args));
-			$str .= "\n";
+			$str .= "\n" if ($priority < scalar(@{ $self->items }) - 1);
 		}
 	}
 

--- a/lib/Chleb/Server/MediaType.pm
+++ b/lib/Chleb/Server/MediaType.pm
@@ -95,10 +95,9 @@ sub parseAcceptHeader {
 	my ($class, $str) = @_;
 
 	$str = __resolveObject($str);
-	if (!defined($str) || length($str) == 0) {
+	if (!defined($str) || length($str) < $MINIMUM_LENGTH) {
+		# invalid header under minimum length is not something worth handling, pretend it was valid and */*
 		$str = $DEFAULT_HEADER;
-	} elsif (length($str) < $MINIMUM_LENGTH) {
-		die Chleb::Exception->raise(HTTP_NOT_ACCEPTABLE, 'Accept: header too short'); # FIXME: '*' is apparently a valid Accept header
 	}
 
 	my $dic = Chleb::DI::Container->instance;

--- a/lib/Chleb/Server/MediaType.pm
+++ b/lib/Chleb/Server/MediaType.pm
@@ -55,6 +55,9 @@ use Scalar::Util qw(blessed);
 Readonly my $DEFAULT_HEADER => '*/*';
 Readonly my $MINIMUM_LENGTH => 3;
 
+Readonly our $CONTENT_TYPE_HTML => 'text/html';
+Readonly our $CONTENT_TYPE_JSON => 'application/json';
+
 =head1 ATTRIBUTES
 
 =over
@@ -202,6 +205,38 @@ sub getWeightMap {
 	}
 
 	return \%weightMap;
+}
+
+=item C<acceptToContentType($params, $default)>
+
+=cut
+
+sub acceptToContentType {
+	my ($params, $default) = @_;
+
+	my $contentType = $default;
+
+	if (my $accept = $params->{accept}) {
+		foreach my $item (reverse(@{ $accept->items })) {
+			if ($item->major eq 'text') {
+				if ($item->minor eq 'html' || $item->minor eq '*') {
+					$contentType = $CONTENT_TYPE_HTML;
+					last;
+				} elsif ($item->minor ne '*') {
+					$contentType = '';
+				}
+			} elsif ($item->major eq 'application') {
+				if ($item->minor eq 'json' || $item->minor eq '*') {
+					$contentType = $CONTENT_TYPE_JSON;
+					last;
+				} elsif ($item->minor ne '*') {
+					$contentType = '';
+				}
+			}
+		}
+	}
+
+	return $contentType;
 }
 
 =item C<toString([$args])>

--- a/lib/Chleb/Server/MediaType.pm
+++ b/lib/Chleb/Server/MediaType.pm
@@ -217,7 +217,7 @@ sub acceptToContentType {
 	my $contentType = $default;
 
 	if ($accept) {
-		foreach my $item (reverse(@{ $accept->items })) {
+		foreach my $item (@{ $accept->items }) {
 			if ($item->major eq 'text') {
 				if ($item->minor eq 'html' || $item->minor eq '*') {
 					$contentType = $CONTENT_TYPE_HTML;

--- a/lib/Chleb/Server/MediaType.pm
+++ b/lib/Chleb/Server/MediaType.pm
@@ -43,6 +43,7 @@ Accept / Content-Type header
 
 =cut
 
+use Chleb::DI::Container;
 use Chleb::Exception;
 use Chleb::Server::MediaType::Item;
 use English qw(-no_match_vars);
@@ -99,6 +100,9 @@ sub parseAcceptHeader {
 	} elsif (length($str) < $MINIMUM_LENGTH) {
 		die Chleb::Exception->raise(HTTP_NOT_ACCEPTABLE, 'Accept: header too short'); # FIXME: '*' is apparently a valid Accept header
 	}
+
+	my $dic = Chleb::DI::Container->instance;
+	$dic->logger->trace("Accept header: '$str'");
 
 	$str =~ s/\s+//g; # remove all whitespace
 	my @types = split(m@,@, lc($str));

--- a/lib/Chleb/Server/MediaType.pm
+++ b/lib/Chleb/Server/MediaType.pm
@@ -45,6 +45,7 @@ Accept / Content-Type header
 
 use Chleb::DI::Container;
 use Chleb::Exception;
+use Chleb::Server::MediaType::Args::ToString;
 use Chleb::Server::MediaType::Item;
 use English qw(-no_match_vars);
 use HTTP::Status qw(:constants);
@@ -149,7 +150,10 @@ sub parseAcceptHeader {
 		original => $str,
 	});
 
-	$dic->logger->trace('Created MediaType object: ' . $object->toString({ verbose => 1 }));
+	$dic->logger->trace('Created MediaType object: ' . $object->toString(
+		Chleb::Server::MediaType::Args::ToString->new(verbose => 1)
+	));
+
 	return $object;
 }
 
@@ -204,24 +208,15 @@ sub getWeightMap {
 
 Return a human-readable string for logging purposes
 
-The C<$args HASH> may contain the following keys:
-
-=over
-
-=item C<verbose>
-
-True of false, default false, indicating whether we call toString() on L</items>.
-
-=back
+C<$args> must be a L<Chleb::Server::MediaType::Args::ToString> object, if present.
 
 =cut
 
 sub toString {
 	my ($self, $args) = @_;
-	my ($verbose) = @{$args}{qw(verbose)};
 
 	my $str = $self->original;
-	if ($verbose) {
+	if ($args->verbose) {
 		$str .= "\n";
 
 		for (my $priority = 0; $priority < scalar(@{ $self->items }); $priority++) {

--- a/lib/Chleb/Server/MediaType.pm
+++ b/lib/Chleb/Server/MediaType.pm
@@ -144,10 +144,13 @@ sub parseAcceptHeader {
 
 	@items = sort { $b->weight <=> $a->weight } @items;
 
-	return $class->new({
+	my $object = $class->new({
 		items => \@items,
 		original => $str,
 	});
+
+	$dic->logger->trace('Created MediaType object: ' . $object->toString());
+	return $object;
 }
 
 =item C<priorityFromTypeStr($typeStr)>

--- a/lib/Chleb/Server/MediaType.pm
+++ b/lib/Chleb/Server/MediaType.pm
@@ -145,6 +145,53 @@ sub parseAcceptHeader {
 	});
 }
 
+=item C<priorityFromTypeStr($typeStr)>
+
+=cut
+
+sub priorityFromTypeStr {
+	my ($self, $typeStr) = @_;
+
+	for (my $priority = 0; $priority < scalar(@{ $self->items }); $priority++) {
+		my $item = $self->items->[$priority];
+		return $priority if ($item->toString() eq $typeStr);
+	}
+
+	#return -1;
+	return 9_999_999; # lowest priority
+}
+
+=item C<getPriorityMap()>
+
+=cut
+
+sub getPriorityMap {
+	my ($self) = @_;
+
+	my %priorityMap = ( );
+	for (my $priority = 0; $priority < scalar(@{ $self->items }); $priority++) { # decreasing priorities
+		my $item = $self->items->[$priority];
+		$priorityMap{ $item->toString() } = $priority;
+	}
+
+	return \%priorityMap;
+}
+
+=item C<getWeightMap()>
+
+=cut
+
+sub getWeightMap {
+	my ($self) = @_;
+
+	my %weightMap = ( );
+	foreach my $item (@{ $self->items }) {
+		$weightMap{ $item->toString() } = $item->weight;
+	}
+
+	return \%weightMap;
+}
+
 =item C<toString()>
 
 Return a human-readable string for logging purposes

--- a/lib/Chleb/Server/MediaType/Args/ToString.pm
+++ b/lib/Chleb/Server/MediaType/Args/ToString.pm
@@ -28,87 +28,11 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-package Chleb::Server::MediaType::Item;
-use Moose;
+package Chleb::Server::MediaType::Args::ToString;
 use strict;
 use warnings;
+use Moose;
 
-=head1 NAME
-
-Chleb::Server::MediaType::Item
-
-=head1 DESCRIPTION
-
-One media item type from an Accept header
-
-=cut
-
-use Chleb::Utils;
-use Moose::Util::TypeConstraints;
-
-=head1 ATTRIBUTES
-
-=over
-
-=item C<major>
-
-The major media type, such as 'application', or 'text'.
-
-=item C<minor>
-
-The minor media type, such as 'html', or 'json'.
-
-=cut
-
-subtype 'Part',
-	as 'Str',
-	where {
-		defined($_) && length($_) > 0 && m/^\S+$/ && ! m@^/+$@
-	},
-	message {
-		'incomplete spec'
-	};
-
-has [qw(major minor)] => (is => 'ro', required => 1, isa => 'Part');
-
-=item C<weight>
-
-The weight, whose default is always 1.0.  Lower values indicate a backup priority only.
-
-TODO: 1.1 and above is illegal, I think?  Check the standards.
-
-=cut
-
-has weight => (is => 'ro', required => 1, isa => 'Num', default => 1.0, required => 1);
-
-=back
-
-=head1 METHODS
-
-=over
-
-=item C<toString([$args])>
-
-Return the media type in the standard major/minor format.
-
-C<$args> must be a L<Chleb::Server::MediaType::Args::ToString> object, if present.
-
-=cut
-
-sub toString {
-	my ($self, $args) = @_;
-	$args = Chleb::Utils::makeDummyArgs($args);
-
-	my $str = join('/', $self->major, $self->minor);
-
-	$str .= sprintf(';q=%.1f', $self->weight)
-	    if ($args->verbose);
-
-	return $str;
-}
-
-=back
-
-=cut
+has verbose => (is => 'ro', isa => 'Bool', default => 0);
 
 1;

--- a/lib/Chleb/Server/MediaType/Item.pm
+++ b/lib/Chleb/Server/MediaType/Item.pm
@@ -43,7 +43,7 @@ One media item type from an Accept header
 
 =cut
 
-use Chleb::Utils;
+use Chleb::Args::Base;
 use Moose::Util::TypeConstraints;
 
 =head1 ATTRIBUTES
@@ -97,7 +97,7 @@ C<$args> must be a L<Chleb::Server::MediaType::Args::ToString> object, if presen
 
 sub toString {
 	my ($self, $args) = @_;
-	$args = Chleb::Utils::makeDummyArgs($args);
+	$args = Chleb::Args::Base::makeDummy($args);
 
 	my $str = join('/', $self->major, $self->minor);
 

--- a/lib/Chleb/Server/MediaType/Item.pm
+++ b/lib/Chleb/Server/MediaType/Item.pm
@@ -97,7 +97,7 @@ C<$args> must be a L<Chleb::Server::MediaType::Args::ToString> object, if presen
 
 sub toString {
 	my ($self, $args) = @_;
-	$args = Chleb::Args::Base::makeDummy($args);
+	$args = Chleb::Args::Base::makeDummy('Chleb::Server::MediaType::Args::ToString', $args);
 
 	my $str = join('/', $self->major, $self->minor);
 

--- a/lib/Chleb/Server/MediaType/Item.pm
+++ b/lib/Chleb/Server/MediaType/Item.pm
@@ -86,15 +86,32 @@ has weight => (is => 'ro', required => 1, isa => 'Num', default => 1.0, required
 
 =over
 
-=item C<toString()>
+=item C<toString([$args])>
 
 Return the media type in the standard major/minor format.
+
+The C<$args HASH> may contain the following keys:
+
+=over
+
+=item C<verbose>
+
+True of false, default false, indicating whether to include the L</weight>.
+
+=back
 
 =cut
 
 sub toString {
-	my ($self) = @_;
-	return join('/', $self->major, $self->minor);
+	my ($self, $args) = @_;
+	my ($verbose) = @{$args}{qw(verbose)};
+
+	my $str = join('/', $self->major, $self->minor);
+
+	$str .= sprintf(';q=%.1f', $self->weight)
+	    if ($verbose);
+
+	return $str;
 }
 
 =back

--- a/lib/Chleb/Utils.pm
+++ b/lib/Chleb/Utils.pm
@@ -101,7 +101,7 @@ sub queryParamsHelper {
 
 	my $str = '';
 	my $counter = 0;
-	my %blacklist = map { $_ => 1 } (qw(book chapter translation verse version when)); # TODO: We should aim to eliminate this hack
+	my %blacklist = map { $_ => 1 } (qw(book chapter contentType translation verse version when)); # TODO: We should aim to eliminate this hack
 
 	while (my ($k, $v) = each(%$params)) {
 		next if ($blacklist{$k});

--- a/lib/Chleb/Utils.pm
+++ b/lib/Chleb/Utils.pm
@@ -12,6 +12,7 @@ Functions for miscellaneous internal purposes
 
 =cut
 
+use Chleb::Server::MediaType::Args::ToString;
 use Scalar::Util qw(blessed);
 
 =head1 FUNCTIONS
@@ -113,6 +114,12 @@ sub queryParamsHelper {
 	}
 
 	return $str;
+}
+
+sub makeDummyArgs {
+	my ($class, $args) = @_; # TODO; ignored $class
+	return $args if ($args); # shortcut
+	return Chleb::Server::MediaType::Args::ToString->new();
 }
 
 =back

--- a/lib/Chleb/Utils.pm
+++ b/lib/Chleb/Utils.pm
@@ -101,7 +101,7 @@ sub queryParamsHelper {
 
 	my $str = '';
 	my $counter = 0;
-	my %blacklist = map { $_ => 1 } (qw(book chapter contentType translation verse version when)); # TODO: We should aim to eliminate this hack
+	my %blacklist = map { $_ => 1 } (qw(accept book chapter translation verse version when)); # TODO: We should aim to eliminate this hack
 
 	while (my ($k, $v) = each(%$params)) {
 		next if ($blacklist{$k});

--- a/lib/Chleb/Utils.pm
+++ b/lib/Chleb/Utils.pm
@@ -12,7 +12,6 @@ Functions for miscellaneous internal purposes
 
 =cut
 
-use Chleb::Server::MediaType::Args::ToString;
 use Scalar::Util qw(blessed);
 
 =head1 FUNCTIONS
@@ -114,12 +113,6 @@ sub queryParamsHelper {
 	}
 
 	return $str;
-}
-
-sub makeDummyArgs {
-	my ($class, $args) = @_; # TODO; ignored $class
-	return $args if ($args); # shortcut
-	return Chleb::Server::MediaType::Args::ToString->new();
 }
 
 =back

--- a/t/Server_MediaType.t
+++ b/t/Server_MediaType.t
@@ -39,12 +39,24 @@ use lib 'externals/libtest-module-runnable-perl/lib';
 extends 'Test::Module::Runnable';
 
 use Chleb;
+use Chleb::DI::Container;
 use Chleb::DI::MockLogger;
 use Chleb::Server::MediaType;
 use English qw(-no_match_vars);
 use POSIX qw(EXIT_SUCCESS);
 use Test::Deep qw(all cmp_deeply isa methods re ignore num);
 use Test::More 0.96;
+
+has dic => (isa => 'Chleb::DI::Container', is => 'rw');
+
+sub setUp {
+	my ($self) = @_;
+
+	$self->dic(Chleb::DI::Container->instance);
+	$self->__mockLogger();
+
+	return EXIT_SUCCESS;
+}
 
 sub testAny {
 	my ($self) = @_;
@@ -346,6 +358,12 @@ sub testMultiTypeWeightedAndWhitespace {
 	), 'type inspection') or diag(explain($mediaType->toString()));
 
 	return EXIT_SUCCESS;
+}
+
+sub __mockLogger {
+	my ($self) = @_;
+	$self->dic->logger(Chleb::DI::MockLogger->new());
+	return;
 }
 
 package main;

--- a/t/Server_MediaType.t
+++ b/t/Server_MediaType.t
@@ -373,11 +373,11 @@ sub testMalformed {
 	};
 
 	if (my $evalError = $EVAL_ERROR) {
-		my $description = 'Accept: Validation failed for \'Num\' with value "0.9;application/json;q=100"';
+		my $description = 'Accept: Validation failed for \'Num\' with value';
 		cmp_deeply($evalError, all(
 			isa('Chleb::Exception'),
 			methods(
-				description => $description,
+				description => re(qr/^$description /),
 				location    => undef,
 				statusCode  => 406,
 			),

--- a/t/Server_MediaType.t
+++ b/t/Server_MediaType.t
@@ -363,6 +363,33 @@ sub testMultiTypeWeightedAndWhitespace {
 	return EXIT_SUCCESS;
 }
 
+sub testMalformed {
+	my ($self) = @_;
+
+	my $input = 'text/plain,application/xhtml+xml,*/*;q=0.8,application/xml;q=0.9;application/json;q=100';
+
+	eval {
+		Chleb::Server::MediaType->parseAcceptHeader($input);
+	};
+
+	if (my $evalError = $EVAL_ERROR) {
+		my $description = 'Accept: Validation failed for \'Num\' with value "0.9;application/json;q=100"';
+		cmp_deeply($evalError, all(
+			isa('Chleb::Exception'),
+			methods(
+				description => $description,
+				location    => undef,
+				statusCode  => 406,
+			),
+		), "'${input}': ${description}");
+	} else {
+		fail("'${input}': No exception raised, as was expected");
+	}
+
+
+	return EXIT_SUCCESS;
+}
+
 sub __mockLogger {
 	my ($self) = @_;
 	$self->dic->logger(Chleb::DI::MockLogger->new());

--- a/t/Server_MediaType_acceptToContentType.t
+++ b/t/Server_MediaType_acceptToContentType.t
@@ -1,0 +1,235 @@
+#!/usr/bin/env perl
+# Chleb Bible Search
+# Copyright (c) 2024, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#     * Neither the name of the Daybo Logic nor the names of its contributors
+#       may be used to endorse or promote products derived from this software
+#       without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+package MediaTypeAcceptToContentTypeTests;
+use strict;
+use warnings;
+use Moose;
+
+use lib 'externals/libtest-module-runnable-perl/lib';
+
+extends 'Test::Module::Runnable';
+
+use POSIX qw(EXIT_SUCCESS);
+use Chleb::DI::Container;
+use Chleb::DI::MockLogger;
+use Chleb::Server;
+use English qw(-no_match_vars);
+use Test::Deep qw(all cmp_deeply isa methods re ignore);
+use Test::More 0.96;
+
+sub setUp {
+	my ($self) = @_;
+
+	$self->__mockLogger();
+
+	return EXIT_SUCCESS;
+}
+
+sub testJsonAndHtml {
+	my ($self) = @_;
+	plan tests => 1;
+
+	my $mediaType = Chleb::Server::MediaType->new({
+		items => [
+			Chleb::Server::MediaType::Item->new({
+				major => 'application',
+				minor => 'json',
+			}),
+			Chleb::Server::MediaType::Item->new({
+				major => 'text',
+				minor => 'html',
+			}),
+		],
+		original => '', # required but unused
+	});
+
+	my $default = $self->uniqueStr();
+	my $contentType = Chleb::Server::MediaType::acceptToContentType($mediaType, $default);
+	is($contentType, 'application/json');
+
+	return EXIT_SUCCESS;
+}
+
+sub testHtmlAndJson {
+	my ($self) = @_;
+	plan tests => 1;
+
+	my $mediaType = Chleb::Server::MediaType->new({
+		items => [
+			Chleb::Server::MediaType::Item->new({
+				major => 'text',
+				minor => 'html',
+			}),
+			Chleb::Server::MediaType::Item->new({
+				major => 'application',
+				minor => 'json',
+			}),
+		],
+		original => '', # required but unused
+	});
+
+	my $default = $self->uniqueStr();
+	my $contentType = Chleb::Server::MediaType::acceptToContentType($mediaType, $default);
+	is($contentType, 'text/html');
+
+	return EXIT_SUCCESS;
+}
+
+sub testAcceptAnythingOnly {
+	my ($self) = @_;
+	plan tests => 1;
+
+	my $mediaType = Chleb::Server::MediaType->parseAcceptHeader('*/*');
+
+	my $default = $self->uniqueStr();
+	my $contentType = Chleb::Server::MediaType::acceptToContentType($mediaType, $default);
+	is($contentType, $default);
+
+	return EXIT_SUCCESS;
+}
+
+sub testAcceptJsonOnly {
+	my ($self) = @_;
+	plan tests => 1;
+
+	my $mediaType = Chleb::Server::MediaType->parseAcceptHeader('application/json');
+
+	my $default = $self->uniqueStr();
+	my $contentType = Chleb::Server::MediaType::acceptToContentType($mediaType, $default);
+	is($contentType, 'application/json');
+
+	return EXIT_SUCCESS;
+}
+
+sub testAcceptHtmlOnly {
+	my ($self) = @_;
+	plan tests => 1;
+
+	my $mediaType = Chleb::Server::MediaType->parseAcceptHeader('text/html');
+
+	my $default = $self->uniqueStr();
+	my $contentType = Chleb::Server::MediaType::acceptToContentType($mediaType, $default);
+	is($contentType, 'text/html');
+
+	return EXIT_SUCCESS;
+}
+
+sub testAcceptTextPlainOnly {
+	my ($self) = @_;
+	plan tests => 1;
+
+	my $mediaType = Chleb::Server::MediaType->parseAcceptHeader('text/plain');
+
+	my $default = $self->uniqueStr();
+	my $contentType = Chleb::Server::MediaType::acceptToContentType($mediaType, $default);
+	is($contentType, '');
+
+	return EXIT_SUCCESS;
+}
+
+sub testAcceptDefault {
+	my ($self) = @_;
+	plan tests => 1;
+
+	my $default = $self->uniqueStr();
+	my $contentType = Chleb::Server::MediaType::acceptToContentType(undef, $default);
+	is($contentType, $default);
+
+	return EXIT_SUCCESS;
+}
+
+sub testAcceptTextAnythingOnly {
+	my ($self) = @_;
+	plan tests => 1;
+
+	my $mediaType = Chleb::Server::MediaType->parseAcceptHeader('text/*');
+
+	my $default = $self->uniqueStr();
+	my $contentType = Chleb::Server::MediaType::acceptToContentType($mediaType, $default);
+	is($contentType, 'text/html');
+
+	return EXIT_SUCCESS;
+}
+
+sub testAcceptApplicationAnythingOnly {
+	my ($self) = @_;
+	plan tests => 1;
+
+	my $mediaType = Chleb::Server::MediaType->parseAcceptHeader('application/*');
+
+	my $default = $self->uniqueStr();
+	my $contentType = Chleb::Server::MediaType::acceptToContentType($mediaType, $default);
+	is($contentType, 'application/json');
+
+	return EXIT_SUCCESS;
+}
+
+sub testAcceptApplicationJsonOnly {
+	my ($self) = @_;
+	plan tests => 1;
+
+	my $mediaType = Chleb::Server::MediaType->parseAcceptHeader('application/json');
+
+	my $default = $self->uniqueStr();
+	my $contentType = Chleb::Server::MediaType::acceptToContentType($mediaType, $default);
+	is($contentType, 'application/json');
+
+	return EXIT_SUCCESS;
+}
+
+sub testAcceptApplicationTypoOnly {
+	my ($self) = @_;
+	plan tests => 1;
+
+	my $mediaType = Chleb::Server::MediaType->parseAcceptHeader('application/jsom');
+
+	my $default = $self->uniqueStr();
+	my $contentType = Chleb::Server::MediaType::acceptToContentType($mediaType, $default);
+	is($contentType, '');
+
+	return EXIT_SUCCESS;
+}
+
+sub __mockLogger {
+	my ($self) = @_;
+
+	my $dic = Chleb::DI::Container->instance;
+	$dic->logger(Chleb::DI::MockLogger->new());
+
+	return;
+}
+
+package main;
+use strict;
+use warnings;
+
+exit(MediaTypeAcceptToContentTypeTests->new->run());

--- a/t/Server_votd.t
+++ b/t/Server_votd.t
@@ -144,7 +144,8 @@ sub testV2 {
 	plan tests => 1;
 
 	my $when = '1971-04-28T12:00:00+0100';
-	my $json = $self->sut->__votd({ version => 2, when => $when });
+	my $mediaType = Chleb::Server::MediaType->parseAcceptHeader('application/json');
+	my $json = $self->sut->__votd({ version => 2, when => $when, accept => $mediaType });
 	cmp_deeply($json, {
 		data => [
 			{

--- a/t/Server_votd.t
+++ b/t/Server_votd.t
@@ -293,7 +293,8 @@ sub testV2_translations_asv_asv {
 	plan tests => 1;
 
 	my $when = '2024-10-30T21:36:26+0000';
-	my $json = $self->sut->__votd({ version => 2, when => $when, translations => ['asv', 'asv'] });
+	my $mediaType = Chleb::Server::MediaType->parseAcceptHeader('application/json');
+	my $json = $self->sut->__votd({ accept => $mediaType, version => 2, when => $when, translations => ['asv', 'asv'] });
 	cmp_deeply($json, {
 		data => [
 			{
@@ -377,7 +378,8 @@ sub testV2_translations_kjv_asv {
 	plan tests => 1;
 
 	my $when = '2024-10-30T21:36:26+0000';
-	my $json = $self->sut->__votd({ version => 2, when => $when, translations => ['kjv', 'asv'] });
+	my $mediaType = Chleb::Server::MediaType->parseAcceptHeader('application/json');
+	my $json = $self->sut->__votd({ accept => $mediaType, version => 2, when => $when, translations => ['kjv', 'asv'] });
 	cmp_deeply($json, {
 		data => [
 			{
@@ -493,7 +495,8 @@ sub testV2_translations_all {
 	plan tests => 1;
 
 	my $when = '2021-10-30T21:36:26+0000';
-	my $json = $self->sut->__votd({ version => 2, when => $when, translations => ['all'] });
+	my $mediaType = Chleb::Server::MediaType->parseAcceptHeader('application/json');
+	my $json = $self->sut->__votd({ accept => $mediaType, version => 2, when => $when, translations => ['all'] });
 	cmp_deeply($json, {
 		data => [
 			{


### PR DESCRIPTION
Default to text/html for /2/votd

nb. this is a breaking change because now users will need to pass Accept: application/json for programmatic access!
This allows us to open up to a wider audience, so people can use the links in primitive applications and send people links to biblical references.  In the near future, we can expand this to direct lookups or possibly searches?