### PR TITLE
✅ move mock logger setup into base class

### DIFF
--- a/t/Base.t
+++ b/t/Base.t
@@ -2,14 +2,15 @@
 package BaseTests;
 use strict;
 use warnings;
+use lib 't/lib';
 use Moose;
 
 use lib 'externals/libtest-module-runnable-perl/lib';
 
-extends 'Test::Module::Runnable';
+extends 'Test::Module::Runnable::Local';
 
 use English qw(-no_match_vars);
-use POSIX qw(EXIT_SUCCESS);
+use POSIX qw(EXIT_FAILURE EXIT_SUCCESS);
 use Chleb::Bible::Base;
 use Chleb::DI::MockLogger;
 use Test::Deep qw(cmp_deeply all isa methods bool re);
@@ -17,10 +18,13 @@ use Test::Exception;
 use Test::More;
 
 sub setUp {
-	my ($self) = @_;
+	my ($self, %params) = @_;
+
+	if (EXIT_SUCCESS != $self->SUPER::setUp(%params)) {
+		return EXIT_FAILURE;
+	}
 
 	$self->sut(Chleb::Bible::Base->new());
-	$self->__mockLogger();
 
 	return EXIT_SUCCESS;
 }
@@ -97,12 +101,6 @@ sub testMangledPlus {
 	$str);
 
 	return EXIT_SUCCESS;
-}
-
-sub __mockLogger {
-	my ($self) = @_;
-	$self->sut->dic->logger(Chleb::DI::MockLogger->new());
-	return;
 }
 
 package main;

--- a/t/Bible_getVerseByOrdinal.t
+++ b/t/Bible_getVerseByOrdinal.t
@@ -42,7 +42,7 @@ extends 'Test::Module::Runnable::Local';
 use Chleb;
 use Chleb::DI::MockLogger;
 use English qw(-no_match_vars);
-use POSIX qw(EXIT_SUCCESS);
+use POSIX qw(EXIT_FAILURE EXIT_SUCCESS);
 use Test::Deep qw(all cmp_deeply isa methods);
 use Test::Exception;
 use Test::More 0.96;
@@ -50,11 +50,11 @@ use Test::More 0.96;
 sub setUp {
 	my ($self, %params) = @_;
 
-	if (EXIT_SUCCESS == $self->SUPER::setUp(%params)) {
-		$self->sut(Chleb->new({
-			dic => $self->_dic,
-		}));
+	if (EXIT_SUCCESS != $self->SUPER::setUp(%params)) {
+		return EXIT_FAILURE;
 	}
+
+	$self->sut(Chleb->new());
 
 	return EXIT_SUCCESS;
 }

--- a/t/Bible_getVerseByOrdinal.t
+++ b/t/Bible_getVerseByOrdinal.t
@@ -32,11 +32,12 @@
 package Bible_getVerseByOrdinalTests;
 use strict;
 use warnings;
+use lib 't/lib';
 use Moose;
 
 use lib 'externals/libtest-module-runnable-perl/lib';
 
-extends 'Test::Module::Runnable';
+extends 'Test::Module::Runnable::Local';
 
 use Chleb;
 use Chleb::DI::MockLogger;
@@ -47,18 +48,15 @@ use Test::Exception;
 use Test::More 0.96;
 
 sub setUp {
-	my ($self) = @_;
+	my ($self, %params) = @_;
 
-	$self->sut(Chleb->new());
-	$self->__mockLogger();
+	if (EXIT_SUCCESS == $self->SUPER::setUp(%params)) {
+		$self->sut(Chleb->new({
+			dic => $self->_dic,
+		}));
+	}
 
 	return EXIT_SUCCESS;
-}
-
-sub __mockLogger {
-	my ($self) = @_;
-	$self->sut->dic->logger(Chleb::DI::MockLogger->new());
-	return;
 }
 
 sub testFirstSuccess {

--- a/t/Book_getVerseByOrdinal.t
+++ b/t/Book_getVerseByOrdinal.t
@@ -32,32 +32,30 @@
 package Book_getVerseByOrdinalTests;
 use strict;
 use warnings;
+use lib 't/lib';
 use Moose;
 
 use lib 'externals/libtest-module-runnable-perl/lib';
 
-extends 'Test::Module::Runnable';
+extends 'Test::Module::Runnable::Local';
 
 use Test::Deep qw(all cmp_deeply isa methods);
-use POSIX qw(EXIT_SUCCESS);
+use POSIX qw(EXIT_FAILURE EXIT_SUCCESS);
 use Chleb;
 use Chleb::DI::MockLogger;
 use Test::Exception;
 use Test::More 0.96;
 
 sub setUp {
-	my ($self) = @_;
+	my ($self, %params) = @_;
+
+	if (EXIT_SUCCESS != $self->SUPER::setUp(%params)) {
+		return EXIT_FAILURE;
+	}
 
 	$self->sut(Chleb->new());
-	$self->__mockLogger();
 
 	return EXIT_SUCCESS;
-}
-
-sub __mockLogger {
-	my ($self) = @_;
-	$self->sut->dic->logger(Chleb::DI::MockLogger->new());
-	return;
 }
 
 sub testSuccess {

--- a/t/Chleb_getBible.t
+++ b/t/Chleb_getBible.t
@@ -32,11 +32,12 @@
 package ChlebGetBibleTests;
 use strict;
 use warnings;
+use lib 't/lib';
 use Moose;
 
 use lib 'externals/libtest-module-runnable-perl/lib';
 
-extends 'Test::Module::Runnable';
+extends 'Test::Module::Runnable::Local';
 
 use Chleb;
 use Chleb::DI::MockLogger;
@@ -47,10 +48,11 @@ use Test::Exception;
 use Test::More 0.96;
 
 sub setUp {
-	my ($self) = @_;
+	my ($self, %params) = @_;
 
-	$self->sut(Chleb->new());
-	$self->__mockLogger();
+	if (EXIT_SUCCESS == $self->SUPER::setUp(%params)) {
+		$self->sut(Chleb->new());
+	}
 
 	return EXIT_SUCCESS;
 }
@@ -146,12 +148,6 @@ sub testFail {
 	}
 
 	return EXIT_SUCCESS;
-}
-
-sub __mockLogger {
-	my ($self) = @_;
-	$self->sut->dic->logger(Chleb::DI::MockLogger->new());
-	return;
 }
 
 package main;

--- a/t/Chleb_getBible.t
+++ b/t/Chleb_getBible.t
@@ -42,7 +42,7 @@ extends 'Test::Module::Runnable::Local';
 use Chleb;
 use Chleb::DI::MockLogger;
 use English qw(-no_match_vars);
-use POSIX qw(EXIT_SUCCESS);
+use POSIX qw(EXIT_FAILURE EXIT_SUCCESS);
 use Test::Deep qw(all cmp_deeply isa methods);
 use Test::Exception;
 use Test::More 0.96;
@@ -50,9 +50,11 @@ use Test::More 0.96;
 sub setUp {
 	my ($self, %params) = @_;
 
-	if (EXIT_SUCCESS == $self->SUPER::setUp(%params)) {
-		$self->sut(Chleb->new());
+	if (EXIT_SUCCESS != $self->SUPER::setUp(%params)) {
+		return EXIT_FAILURE;
 	}
+
+	$self->sut(Chleb->new());
 
 	return EXIT_SUCCESS;
 }

--- a/t/Chleb_getTranslation.t
+++ b/t/Chleb_getTranslation.t
@@ -44,14 +44,6 @@ use Test::Deep qw(cmp_deeply);
 use Test::Exception;
 use Test::More 0.96;
 
-sub setUp {
-	my ($self) = @_;
-
-#	$self->sut(Chleb->new());
-
-	return EXIT_SUCCESS;
-}
-
 sub testSimple {
 	my ($self) = @_;
 	plan tests => 4;

--- a/t/Server_MediaType.t
+++ b/t/Server_MediaType.t
@@ -32,11 +32,12 @@
 package ServerMediaTypeTests;
 use strict;
 use warnings;
+use lib 't/lib';
 use Moose;
 
 use lib 'externals/libtest-module-runnable-perl/lib';
 
-extends 'Test::Module::Runnable';
+extends 'Test::Module::Runnable::Local';
 
 use Chleb;
 use Chleb::DI::Container;
@@ -51,12 +52,8 @@ use Test::More 0.96;
 has dic => (isa => 'Chleb::DI::Container', is => 'rw');
 
 sub setUp {
-	my ($self) = @_;
-
-	$self->dic(Chleb::DI::Container->instance);
-	$self->__mockLogger();
-
-	return EXIT_SUCCESS;
+	my ($self, %params) = @_;
+	return $self->SUPER::setUp(%params);
 }
 
 sub testAny {
@@ -388,12 +385,6 @@ sub testMalformed {
 
 
 	return EXIT_SUCCESS;
-}
-
-sub __mockLogger {
-	my ($self) = @_;
-	$self->dic->logger(Chleb::DI::MockLogger->new());
-	return;
 }
 
 package main;

--- a/t/Server_MediaType.t
+++ b/t/Server_MediaType.t
@@ -49,13 +49,6 @@ use Test::Deep qw(all cmp_deeply isa methods re ignore num);
 use Test::Exception;
 use Test::More 0.96;
 
-has dic => (isa => 'Chleb::DI::Container', is => 'rw');
-
-sub setUp {
-	my ($self, %params) = @_;
-	return $self->SUPER::setUp(%params);
-}
-
 sub testAny {
 	my ($self) = @_;
 	plan tests => 3;

--- a/t/Server_MediaType_acceptToContentType.t
+++ b/t/Server_MediaType_acceptToContentType.t
@@ -39,7 +39,7 @@ use lib 'externals/libtest-module-runnable-perl/lib';
 
 extends 'Test::Module::Runnable::Local';
 
-use POSIX qw(EXIT_FAILURE EXIT_SUCCESS);
+use POSIX qw(EXIT_SUCCESS);
 use Chleb::DI::Container;
 use Chleb::DI::MockLogger;
 use Chleb::Server;

--- a/t/Server_MediaType_acceptToContentType.t
+++ b/t/Server_MediaType_acceptToContentType.t
@@ -32,27 +32,20 @@
 package MediaTypeAcceptToContentTypeTests;
 use strict;
 use warnings;
+use lib 't/lib';
 use Moose;
 
 use lib 'externals/libtest-module-runnable-perl/lib';
 
-extends 'Test::Module::Runnable';
+extends 'Test::Module::Runnable::Local';
 
-use POSIX qw(EXIT_SUCCESS);
+use POSIX qw(EXIT_FAILURE EXIT_SUCCESS);
 use Chleb::DI::Container;
 use Chleb::DI::MockLogger;
 use Chleb::Server;
 use English qw(-no_match_vars);
 use Test::Deep qw(all cmp_deeply isa methods re ignore);
 use Test::More 0.96;
-
-sub setUp {
-	my ($self) = @_;
-
-	$self->__mockLogger();
-
-	return EXIT_SUCCESS;
-}
 
 sub testJsonAndHtml {
 	my ($self) = @_;
@@ -230,15 +223,6 @@ sub testOnlyUnhandled {
 	is($contentType, '');
 
 	return EXIT_SUCCESS;
-}
-
-sub __mockLogger {
-	my ($self) = @_;
-
-	my $dic = Chleb::DI::Container->instance;
-	$dic->logger(Chleb::DI::MockLogger->new());
-
-	return;
 }
 
 package main;

--- a/t/Server_lookup.t
+++ b/t/Server_lookup.t
@@ -32,14 +32,15 @@
 package LookupServerTests;
 use strict;
 use warnings;
+use lib 't/lib';
 use Moose;
 
 use lib 'externals/libtest-module-runnable-perl/lib';
 
-extends 'Test::Module::Runnable';
+extends 'Test::Module::Runnable::Local';
 
 use English qw(-no_match_vars);
-use POSIX qw(EXIT_SUCCESS);
+use POSIX qw(EXIT_FAILURE EXIT_SUCCESS);
 use Chleb::DI::Container;
 use Chleb::DI::MockLogger;
 use Chleb::Server;
@@ -47,9 +48,12 @@ use Test::Deep qw(all cmp_deeply isa methods re ignore);
 use Test::More 0.96;
 
 sub setUp {
-	my ($self) = @_;
+	my ($self, %params) = @_;
 
-	$self->__mockLogger();
+	if (EXIT_SUCCESS != $self->SUPER::setUp(%params)) {
+		return EXIT_FAILURE;
+	}
+
 	$self->sut(Chleb::Server->new());
 
 	return EXIT_SUCCESS;
@@ -195,15 +199,6 @@ sub test_not_found {
 	}
 
 	return EXIT_SUCCESS;
-}
-
-sub __mockLogger {
-	my ($self) = @_;
-
-	my $dic = Chleb::DI::Container->instance;
-	$dic->logger(Chleb::DI::MockLogger->new());
-
-	return;
 }
 
 package main;

--- a/t/Server_ping.t
+++ b/t/Server_ping.t
@@ -39,7 +39,7 @@ use lib 'externals/libtest-module-runnable-perl/lib';
 
 extends 'Test::Module::Runnable::Local';
 
-use POSIX qw(EXIT_SUCCESS);
+use POSIX qw(EXIT_FAILURE EXIT_SUCCESS);
 use Chleb::DI::Container;
 use Chleb::DI::MockLogger;
 use Chleb::Server;
@@ -49,11 +49,11 @@ use Test::More 0.96;
 sub setUp {
 	my ($self, %params) = @_;
 
-	if (EXIT_SUCCESS == $self->SUPER::setUp(%params)) {
-		$self->sut(Chleb::Server->new({
-			dic => $self->_dic,
-		}));
+	if (EXIT_SUCCESS != $self->SUPER::setUp(%params)) {
+		return EXIT_FAILURE;
 	}
+
+	$self->sut(Chleb::Server->new());
 
 	return EXIT_SUCCESS;
 }

--- a/t/Server_ping.t
+++ b/t/Server_ping.t
@@ -32,11 +32,12 @@
 package PingServerTests;
 use strict;
 use warnings;
+use lib 't/lib';
 use Moose;
 
 use lib 'externals/libtest-module-runnable-perl/lib';
 
-extends 'Test::Module::Runnable';
+extends 'Test::Module::Runnable::Local';
 
 use POSIX qw(EXIT_SUCCESS);
 use Chleb::DI::Container;
@@ -46,10 +47,13 @@ use Test::Deep qw(all cmp_deeply isa methods re ignore);
 use Test::More 0.96;
 
 sub setUp {
-	my ($self) = @_;
+	my ($self, %params) = @_;
 
-	$self->__mockLogger();
-	$self->sut(Chleb::Server->new());
+	if (EXIT_SUCCESS == $self->SUPER::setUp(%params)) {
+		$self->sut(Chleb::Server->new({
+			dic => $self->_dic,
+		}));
+	}
 
 	return EXIT_SUCCESS;
 }
@@ -71,15 +75,6 @@ sub testPing {
 	}, '__ping') or diag(explain($json));
 
 	return EXIT_SUCCESS;
-}
-
-sub __mockLogger {
-	my ($self) = @_;
-
-	my $dic = Chleb::DI::Container->instance;
-	$dic->logger(Chleb::DI::MockLogger->new());
-
-	return;
 }
 
 package main;

--- a/t/Server_random.t
+++ b/t/Server_random.t
@@ -53,9 +53,7 @@ sub setUp {
 		return EXIT_FAILURE;
 	}
 
-	$self->sut(Chleb::Server->new({
-		dic => $self->_dic,
-	}));
+	$self->sut(Chleb::Server->new());
 
 	return EXIT_SUCCESS;
 }

--- a/t/Server_random.t
+++ b/t/Server_random.t
@@ -32,13 +32,14 @@
 package RandomServerTests;
 use strict;
 use warnings;
+use lib 't/lib';
 use Moose;
 
 use lib 'externals/libtest-module-runnable-perl/lib';
 
-extends 'Test::Module::Runnable';
+extends 'Test::Module::Runnable::Local';
 
-use POSIX qw(EXIT_SUCCESS);
+use POSIX qw(EXIT_FAILURE EXIT_SUCCESS);
 use Chleb::DI::Container;
 use Chleb::DI::MockLogger;
 use Chleb::Server;
@@ -46,10 +47,15 @@ use Test::Deep qw(all cmp_deeply isa methods re ignore);
 use Test::More 0.96;
 
 sub setUp {
-	my ($self) = @_;
+	my ($self, %params) = @_;
 
-	$self->__mockLogger();
-	$self->sut(Chleb::Server->new());
+	if (EXIT_SUCCESS != $self->SUPER::setUp(%params)) {
+		return EXIT_FAILURE;
+	}
+
+	$self->sut(Chleb::Server->new({
+		dic => $self->_dic,
+	}));
 
 	return EXIT_SUCCESS;
 }
@@ -304,15 +310,6 @@ sub test_translation_all {
 	}, "single random verse JSON") or diag(explain($json));
 
 	return EXIT_SUCCESS;
-}
-
-sub __mockLogger {
-	my ($self) = @_;
-
-	my $dic = Chleb::DI::Container->instance;
-	$dic->logger(Chleb::DI::MockLogger->new());
-
-	return;
 }
 
 package main;

--- a/t/Server_search.t
+++ b/t/Server_search.t
@@ -32,13 +32,14 @@
 package SearchServerTests;
 use strict;
 use warnings;
+use lib 't/lib';
 use Moose;
 
 use lib 'externals/libtest-module-runnable-perl/lib';
 
-extends 'Test::Module::Runnable';
+extends 'Test::Module::Runnable::Local';
 
-use POSIX qw(EXIT_SUCCESS);
+use POSIX qw(EXIT_FAILURE EXIT_SUCCESS);
 use Chleb::DI::Container;
 use Chleb::DI::MockLogger;
 use Chleb::Server;
@@ -48,10 +49,15 @@ use Test::Deep qw(all cmp_deeply isa methods re ignore);
 use Test::More 0.96;
 
 sub setUp {
-	my ($self) = @_;
+	my ($self, %params) = @_;
 
-	$self->__mockLogger();
-	$self->sut(Chleb::Server->new());
+	if (EXIT_SUCCESS != $self->SUPER::setUp(%params)) {
+		return EXIT_FAILURE;
+	}
+
+	$self->sut(Chleb::Server->new({
+		dic => $self->_dic,
+	}));
 
 	return EXIT_SUCCESS;
 }
@@ -342,15 +348,6 @@ sub test {
 	}, "wholeword search results for '$term'") or diag(explain($json));
 
 	return EXIT_SUCCESS;
-}
-
-sub __mockLogger {
-	my ($self) = @_;
-
-	my $dic = Chleb::DI::Container->instance;
-	$dic->logger(Chleb::DI::MockLogger->new());
-
-	return;
 }
 
 package main;

--- a/t/Server_search.t
+++ b/t/Server_search.t
@@ -55,9 +55,7 @@ sub setUp {
 		return EXIT_FAILURE;
 	}
 
-	$self->sut(Chleb::Server->new({
-		dic => $self->_dic,
-	}));
+	$self->sut(Chleb::Server->new());
 
 	return EXIT_SUCCESS;
 }

--- a/t/Server_uptime.t
+++ b/t/Server_uptime.t
@@ -32,13 +32,14 @@
 package UptimeServerTests;
 use strict;
 use warnings;
+use lib 't/lib';
 use Moose;
 
 use lib 'externals/libtest-module-runnable-perl/lib';
 
-extends 'Test::Module::Runnable';
+extends 'Test::Module::Runnable::Local';
 
-use POSIX qw(EXIT_SUCCESS);
+use POSIX qw(EXIT_FAILURE EXIT_SUCCESS);
 use Chleb::DI::Container;
 use Chleb::DI::MockLogger;
 use Chleb::Server;
@@ -46,10 +47,15 @@ use Test::Deep qw(all cmp_deeply isa methods re ignore);
 use Test::More 0.96;
 
 sub setUp {
-	my ($self) = @_;
+	my ($self, %params) = @_;
 
-	$self->__mockLogger();
-	$self->sut(Chleb::Server->new());
+	if (EXIT_SUCCESS != $self->SUPER::setUp(%params)) {
+		return EXIT_FAILURE;
+	}
+
+	$self->sut(Chleb::Server->new({
+		dic => $self->_dic,
+	}));
 
 	return EXIT_SUCCESS;
 }
@@ -100,15 +106,6 @@ sub testUptimeDynamic {
 	}, '__uptime: ' . $json->{data}->[0]->{attributes}->{text}) or diag(explain($json));
 
 	return EXIT_SUCCESS;
-}
-
-sub __mockLogger {
-	my ($self) = @_;
-
-	my $dic = Chleb::DI::Container->instance;
-	$dic->logger(Chleb::DI::MockLogger->new());
-
-	return;
 }
 
 package main;

--- a/t/Server_uptime.t
+++ b/t/Server_uptime.t
@@ -53,9 +53,7 @@ sub setUp {
 		return EXIT_FAILURE;
 	}
 
-	$self->sut(Chleb::Server->new({
-		dic => $self->_dic,
-	}));
+	$self->sut(Chleb::Server->new());
 
 	return EXIT_SUCCESS;
 }

--- a/t/Server_version.t
+++ b/t/Server_version.t
@@ -32,13 +32,14 @@
 package VersionServerTests;
 use strict;
 use warnings;
+use lib 't/lib';
 use Moose;
 
 use lib 'externals/libtest-module-runnable-perl/lib';
 
-extends 'Test::Module::Runnable';
+extends 'Test::Module::Runnable::Local';
 
-use POSIX qw(EXIT_SUCCESS);
+use POSIX qw(EXIT_FAILURE EXIT_SUCCESS);
 use Chleb::DI::Container;
 use Chleb::DI::MockLogger;
 use Chleb::Server;
@@ -46,10 +47,15 @@ use Test::Deep qw(all cmp_deeply isa methods re ignore);
 use Test::More 0.96;
 
 sub setUp {
-	my ($self) = @_;
+	my ($self, %params) = @_;
 
-	$self->__mockLogger();
-	$self->sut(Chleb::Server->new());
+	if (EXIT_SUCCESS != $self->SUPER::setUp(%params)) {
+		return EXIT_FAILURE;
+	}
+
+	$self->sut(Chleb::Server->new({
+		dic => $self->_dic,
+	}));
 
 	return EXIT_SUCCESS;
 }
@@ -74,15 +80,6 @@ sub testDefaults {
 	}, '__version') or diag(explain($json));
 
 	return EXIT_SUCCESS;
-}
-
-sub __mockLogger {
-	my ($self) = @_;
-
-	my $dic = Chleb::DI::Container->instance;
-	$dic->logger(Chleb::DI::MockLogger->new());
-
-	return;
 }
 
 package main;

--- a/t/Server_version.t
+++ b/t/Server_version.t
@@ -53,9 +53,7 @@ sub setUp {
 		return EXIT_FAILURE;
 	}
 
-	$self->sut(Chleb::Server->new({
-		dic => $self->_dic,
-	}));
+	$self->sut(Chleb::Server->new());
 
 	return EXIT_SUCCESS;
 }

--- a/t/Server_votd.t
+++ b/t/Server_votd.t
@@ -32,13 +32,14 @@
 package VotdServerTests;
 use strict;
 use warnings;
+use lib 't/lib';
 use Moose;
 
 use lib 'externals/libtest-module-runnable-perl/lib';
 
-extends 'Test::Module::Runnable';
+extends 'Test::Module::Runnable::Local';
 
-use POSIX qw(EXIT_SUCCESS);
+use POSIX qw(EXIT_FAILURE EXIT_SUCCESS);
 use Chleb::DI::Container;
 use Chleb::DI::MockLogger;
 use Chleb::Server;
@@ -47,10 +48,15 @@ use Test::Deep qw(all cmp_deeply isa methods re ignore);
 use Test::More 0.96;
 
 sub setUp {
-	my ($self) = @_;
+	my ($self, %params) = @_;
 
-	$self->__mockLogger();
-	$self->sut(Chleb::Server->new());
+	if (EXIT_SUCCESS != $self->SUPER::setUp(%params)) {
+		return EXIT_FAILURE;
+	}
+
+	$self->sut(Chleb::Server->new({
+		dic => $self->_dic,
+	}));
 
 	return EXIT_SUCCESS;
 }
@@ -747,15 +753,6 @@ sub testRedirectV1 {
 	}
 
 	return EXIT_SUCCESS;
-}
-
-sub __mockLogger {
-	my ($self) = @_;
-
-	my $dic = Chleb::DI::Container->instance;
-	$dic->logger(Chleb::DI::MockLogger->new());
-
-	return;
 }
 
 package main;

--- a/t/Server_votd.t
+++ b/t/Server_votd.t
@@ -54,9 +54,7 @@ sub setUp {
 		return EXIT_FAILURE;
 	}
 
-	$self->sut(Chleb::Server->new({
-		dic => $self->_dic,
-	}));
+	$self->sut(Chleb::Server->new());
 
 	return EXIT_SUCCESS;
 }

--- a/t/lib/Test/Module/Runnable/Local.pm
+++ b/t/lib/Test/Module/Runnable/Local.pm
@@ -38,10 +38,23 @@ use lib 'externals/libtest-module-runnable-perl/lib';
 
 extends 'Test::Module::Runnable';
 
-#use Chleb::DI::MockLogger;
+use Chleb::DI::Container;
+use Chleb::DI::MockLogger;
 use English qw(-no_match_vars);
 use POSIX qw(EXIT_SUCCESS);
 use Test::More 0.96;
+
+has _dic => (isa => 'Chleb::DI::Container', is => 'ro', lazy => 1, default => sub {
+	return Chleb::DI::Container->new();
+});
+
+sub setUp {
+	my ($self, %params) = @_;
+
+	$self->___mockLogger();
+
+	return EXIT_SUCCESS;
+}
 
 sub _isTestComprehensive {
 	my $testComprehensive = !$ENV{TEST_QUICK};
@@ -52,6 +65,17 @@ sub _isTestComprehensive {
 	}
 
 	return $testComprehensive;
+}
+
+sub ___mockLogger {
+	my ($self) = @_;
+
+	$self->_dic->logger(Chleb::DI::MockLogger->new({ dic => $self->_dic }));
+	if ($self->sut && $self->sut->can('dic') && $self->sut->dic) {
+		$self->sut->dic->logger($self->_dic->logger) unless ($self->sut->dic->logger);
+	}
+
+	return;
 }
 
 1;

--- a/t/peace_on_earth.t
+++ b/t/peace_on_earth.t
@@ -32,11 +32,12 @@
 package PeaceOnEarthTests;
 use strict;
 use warnings;
+use lib 't/lib';
 use Moose;
 
 use lib 'externals/libtest-module-runnable-perl/lib';
 
-extends 'Test::Module::Runnable';
+extends 'Test::Module::Runnable::Local';
 
 use Test::Deep qw(all cmp_deeply isa methods);
 use POSIX qw(EXIT_SUCCESS);
@@ -45,10 +46,11 @@ use Chleb::DI::MockLogger;
 use Test::More 0.96;
 
 sub setUp {
-	my ($self) = @_;
+	my ($self, %params) = @_;
 
-	$self->sut(Chleb->new());
-	$self->__mockLogger();
+	if (EXIT_SUCCESS == $self->SUPER::setUp(%params)) {
+		$self->sut(Chleb->new());
+	}
 
 	return EXIT_SUCCESS;
 }
@@ -392,12 +394,6 @@ sub testPeaceSearch_asvTranslationViaBible_direct {
 	), 'results inspection');
 
 	return EXIT_SUCCESS;
-}
-
-sub __mockLogger {
-	my ($self) = @_;
-	$self->sut->dic->logger(Chleb::DI::MockLogger->new());
-	return;
 }
 
 package main;

--- a/t/peace_on_earth.t
+++ b/t/peace_on_earth.t
@@ -40,7 +40,7 @@ use lib 'externals/libtest-module-runnable-perl/lib';
 extends 'Test::Module::Runnable::Local';
 
 use Test::Deep qw(all cmp_deeply isa methods);
-use POSIX qw(EXIT_SUCCESS);
+use POSIX qw(EXIT_FAILURE EXIT_SUCCESS);
 use Chleb;
 use Chleb::DI::MockLogger;
 use Test::More 0.96;
@@ -48,9 +48,11 @@ use Test::More 0.96;
 sub setUp {
 	my ($self, %params) = @_;
 
-	if (EXIT_SUCCESS == $self->SUPER::setUp(%params)) {
-		$self->sut(Chleb->new());
+	if (EXIT_SUCCESS != $self->SUPER::setUp(%params)) {
+		return EXIT_FAILURE;
 	}
+
+	$self->sut(Chleb->new());
 
 	return EXIT_SUCCESS;
 }

--- a/t/peace_on_limit.t
+++ b/t/peace_on_limit.t
@@ -32,11 +32,12 @@
 package PeaceOnEarthTests;
 use strict;
 use warnings;
+use lib 't/lib';
 use Moose;
 
 use lib 'externals/libtest-module-runnable-perl/lib';
 
-extends 'Test::Module::Runnable';
+extends 'Test::Module::Runnable::Local';
 
 use Test::Deep qw(all cmp_deeply isa methods);
 use POSIX qw(EXIT_SUCCESS);
@@ -45,10 +46,11 @@ use Chleb::DI::MockLogger;
 use Test::More 0.96;
 
 sub setUp {
-	my ($self) = @_;
+	my ($self, %params) = @_;
 
-	$self->sut(Chleb->new());
-	$self->__mockLogger();
+	if (EXIT_SUCCESS == $self->SUPER::setUp(%params)) {
+		$self->sut(Chleb->new());
+	}
 
 	return EXIT_SUCCESS;
 }
@@ -160,12 +162,6 @@ sub testPeaceSearch {
 	), 'results inspection');
 
 	return EXIT_SUCCESS;
-}
-
-sub __mockLogger {
-	my ($self) = @_;
-	$self->sut->dic->logger(Chleb::DI::MockLogger->new());
-	return;
 }
 
 package main;

--- a/t/peace_on_limit.t
+++ b/t/peace_on_limit.t
@@ -40,7 +40,7 @@ use lib 'externals/libtest-module-runnable-perl/lib';
 extends 'Test::Module::Runnable::Local';
 
 use Test::Deep qw(all cmp_deeply isa methods);
-use POSIX qw(EXIT_SUCCESS);
+use POSIX qw(EXIT_FAILURE EXIT_SUCCESS);
 use Chleb;
 use Chleb::DI::MockLogger;
 use Test::More 0.96;
@@ -48,9 +48,11 @@ use Test::More 0.96;
 sub setUp {
 	my ($self, %params) = @_;
 
-	if (EXIT_SUCCESS == $self->SUPER::setUp(%params)) {
-		$self->sut(Chleb->new());
+	if (EXIT_SUCCESS != $self->SUPER::setUp(%params)) {
+		return EXIT_FAILURE;
 	}
+
+	$self->sut(Chleb->new());
 
 	return EXIT_SUCCESS;
 }

--- a/t/pride.t
+++ b/t/pride.t
@@ -32,11 +32,12 @@
 package PrideTests;
 use strict;
 use warnings;
+use lib 't/lib';
 use Moose;
 
 use lib 'externals/libtest-module-runnable-perl/lib';
 
-extends 'Test::Module::Runnable';
+extends 'Test::Module::Runnable::Local';
 
 use Chleb;
 use Chleb::DI::MockLogger;
@@ -47,18 +48,15 @@ use Test::Exception;
 use Test::More 0.96;
 
 sub setUp {
-	my ($self) = @_;
+	my ($self, %params) = @_;
 
-	$self->sut(Chleb->new());
-	$self->__mockLogger();
+	if (EXIT_SUCCESS == $self->SUPER::setUp(%params)) {
+		$self->sut(Chleb->new({
+			dic => $self->_dic,
+		}));
+	}
 
 	return EXIT_SUCCESS;
-}
-
-sub __mockLogger {
-	my ($self) = @_;
-	$self->sut->dic->logger(Chleb::DI::MockLogger->new());
-	return;
 }
 
 sub testPride_default {

--- a/t/pride.t
+++ b/t/pride.t
@@ -42,7 +42,7 @@ extends 'Test::Module::Runnable::Local';
 use Chleb;
 use Chleb::DI::MockLogger;
 use English qw(-no_match_vars);
-use POSIX qw(EXIT_SUCCESS);
+use POSIX qw(EXIT_FAILURE EXIT_SUCCESS);
 use Test::Deep qw(all cmp_deeply isa methods);
 use Test::Exception;
 use Test::More 0.96;
@@ -50,11 +50,11 @@ use Test::More 0.96;
 sub setUp {
 	my ($self, %params) = @_;
 
-	if (EXIT_SUCCESS == $self->SUPER::setUp(%params)) {
-		$self->sut(Chleb->new({
-			dic => $self->_dic,
-		}));
+	if (EXIT_SUCCESS != $self->SUPER::setUp(%params)) {
+		return EXIT_FAILURE;
 	}
+
+	$self->sut(Chleb->new());
 
 	return EXIT_SUCCESS;
 }

--- a/t/random.t
+++ b/t/random.t
@@ -32,11 +32,12 @@
 package RandomTests;
 use strict;
 use warnings;
+use lib 't/lib';
 use Moose;
 
 use lib 'externals/libtest-module-runnable-perl/lib';
 
-extends 'Test::Module::Runnable';
+extends 'Test::Module::Runnable::Local';
 
 use POSIX qw(EXIT_SUCCESS);
 use Chleb;
@@ -45,10 +46,13 @@ use Test::Deep qw(all cmp_deeply isa methods re ignore);
 use Test::More 0.96;
 
 sub setUp {
-	my ($self) = @_;
+	my ($self, %params) = @_;
 
-	$self->sut(Chleb->new());
-	$self->__mockLogger();
+	if (EXIT_SUCCESS == $self->SUPER::setUp(%params)) {
+		$self->sut(Chleb->new({
+			dic => $self->_dic,
+		}));
+	}
 
 	return EXIT_SUCCESS;
 }
@@ -69,12 +73,6 @@ sub test {
 	), 'verse inspection') or diag(explain($verse->toString()));
 
 	return EXIT_SUCCESS;
-}
-
-sub __mockLogger {
-	my ($self) = @_;
-	$self->sut->dic->logger(Chleb::DI::MockLogger->new());
-	return;
 }
 
 package main;

--- a/t/random.t
+++ b/t/random.t
@@ -39,7 +39,7 @@ use lib 'externals/libtest-module-runnable-perl/lib';
 
 extends 'Test::Module::Runnable::Local';
 
-use POSIX qw(EXIT_SUCCESS);
+use POSIX qw(EXIT_FAILURE EXIT_SUCCESS);
 use Chleb;
 use Chleb::DI::MockLogger;
 use Test::Deep qw(all cmp_deeply isa methods re ignore);
@@ -48,11 +48,11 @@ use Test::More 0.96;
 sub setUp {
 	my ($self, %params) = @_;
 
-	if (EXIT_SUCCESS == $self->SUPER::setUp(%params)) {
-		$self->sut(Chleb->new({
-			dic => $self->_dic,
-		}));
+	if (EXIT_SUCCESS != $self->SUPER::setUp(%params)) {
+		return EXIT_FAILURE;
 	}
+
+	$self->sut(Chleb->new());
 
 	return EXIT_SUCCESS;
 }

--- a/t/traverse_entire_bible.t
+++ b/t/traverse_entire_bible.t
@@ -41,7 +41,7 @@ extends 'Test::Module::Runnable::Local';
 
 use Chleb;
 use Chleb::DI::MockLogger;
-use POSIX qw(EXIT_SUCCESS);
+use POSIX qw(EXIT_FAILURE EXIT_SUCCESS);
 use Readonly;
 use Test::Deep qw(all cmp_deeply isa methods);
 use Test::More 0.96;
@@ -52,9 +52,11 @@ Readonly my $VERSE_LAST  => 1;
 sub setUp {
 	my ($self, %params) = @_;
 
-	if (EXIT_SUCCESS == $self->SUPER::setUp(%params)) {
-		$self->sut(Chleb->new());
+	if (EXIT_SUCCESS != $self->SUPER::setUp(%params)) {
+		return EXIT_FAILURE;
 	}
+
+	$self->sut(Chleb->new());
 
 	return EXIT_SUCCESS;
 }

--- a/t/traverse_entire_bible.t
+++ b/t/traverse_entire_bible.t
@@ -50,10 +50,11 @@ Readonly my $VERSE_FIRST => 0;
 Readonly my $VERSE_LAST  => 1;
 
 sub setUp {
-	my ($self) = @_;
+	my ($self, %params) = @_;
 
-	$self->sut(Chleb->new());
-	$self->__mockLogger();
+	if (EXIT_SUCCESS == $self->SUPER::setUp(%params)) {
+		$self->sut(Chleb->new());
+	}
 
 	return EXIT_SUCCESS;
 }
@@ -201,12 +202,6 @@ sub __testTraversalReverseWork {
 	my $expectBibleVerseCount = 31_102;
 	is($actualBibleVerseCount, $expectBibleVerseCount, "Bible verse count: $expectBibleVerseCount");
 
-	return;
-}
-
-sub __mockLogger {
-	my ($self) = @_;
-	$self->sut->dic->logger(Chleb::DI::MockLogger->new());
 	return;
 }
 

--- a/t/verse.t
+++ b/t/verse.t
@@ -32,11 +32,12 @@
 package VerseTests;
 use strict;
 use warnings;
+use lib 't/lib';
 use Moose;
 
 use lib 'externals/libtest-module-runnable-perl/lib';
 
-extends 'Test::Module::Runnable';
+extends 'Test::Module::Runnable::Local';
 
 use Test::Deep qw(all cmp_deeply isa methods);
 use POSIX qw(EXIT_SUCCESS);
@@ -49,9 +50,14 @@ use Test::Exception;
 use Test::More 0.96;
 
 sub setUp {
-	my ($self) = @_;
-	$self->sut(Chleb->new());
-	$self->__mockLogger();
+	my ($self, %params) = @_;
+
+	if (EXIT_SUCCESS == $self->SUPER::setUp(%params)) {
+		$self->sut(Chleb->new({
+			dic => $self->_dic,
+		}));
+	}
+
 	return EXIT_SUCCESS;
 }
 
@@ -113,12 +119,6 @@ sub test {
 	}, 'TO_JSON') or diag(explain($json));
 
 	return EXIT_SUCCESS;
-}
-
-sub __mockLogger {
-	my ($self) = @_;
-	$self->sut->dic->logger(Chleb::DI::MockLogger->new());
-	return;
 }
 
 package main;

--- a/t/verse.t
+++ b/t/verse.t
@@ -40,7 +40,7 @@ use lib 'externals/libtest-module-runnable-perl/lib';
 extends 'Test::Module::Runnable::Local';
 
 use Test::Deep qw(all cmp_deeply isa methods);
-use POSIX qw(EXIT_SUCCESS);
+use POSIX qw(EXIT_FAILURE EXIT_SUCCESS);
 use Chleb;
 use Chleb::Bible::Book;
 use Chleb::Bible::Verse;
@@ -52,11 +52,11 @@ use Test::More 0.96;
 sub setUp {
 	my ($self, %params) = @_;
 
-	if (EXIT_SUCCESS == $self->SUPER::setUp(%params)) {
-		$self->sut(Chleb->new({
-			dic => $self->_dic,
-		}));
+	if (EXIT_SUCCESS != $self->SUPER::setUp(%params)) {
+		return EXIT_FAILURE;
 	}
+
+	$self->sut(Chleb->new());
 
 	return EXIT_SUCCESS;
 }

--- a/t/votd.t
+++ b/t/votd.t
@@ -32,11 +32,13 @@
 package VotdTests;
 use strict;
 use warnings;
+use lib 't/lib';
 use Moose;
 
+use lib '.';
 use lib 'externals/libtest-module-runnable-perl/lib';
 
-extends 'Test::Module::Runnable';
+extends 'Test::Module::Runnable::Local';
 
 use Chleb;
 use Chleb::DI::MockLogger;
@@ -45,10 +47,13 @@ use Test::Deep qw(all cmp_deeply isa methods re ignore);
 use Test::More 0.96;
 
 sub setUp {
-	my ($self) = @_;
+	my ($self, %params) = @_;
 
-	$self->sut(Chleb->new());
-	$self->__mockLogger();
+	if (EXIT_SUCCESS == $self->SUPER::setUp(%params)) {
+		$self->sut(Chleb->new({
+			dic => $self->_dic,
+		}));
+	}
 
 	return EXIT_SUCCESS;
 }
@@ -191,12 +196,6 @@ sub testParentalRef {
 	), 'verse inspection, parental') or diag(explain($verse->toString()));
 
 	return EXIT_SUCCESS;
-}
-
-sub __mockLogger {
-	my ($self) = @_;
-	$self->sut->dic->logger(Chleb::DI::MockLogger->new());
-	return;
 }
 
 package main;

--- a/t/votd.t
+++ b/t/votd.t
@@ -42,18 +42,18 @@ extends 'Test::Module::Runnable::Local';
 
 use Chleb;
 use Chleb::DI::MockLogger;
-use POSIX qw(EXIT_SUCCESS);
+use POSIX qw(EXIT_FAILURE EXIT_SUCCESS);
 use Test::Deep qw(all cmp_deeply isa methods re ignore);
 use Test::More 0.96;
 
 sub setUp {
 	my ($self, %params) = @_;
 
-	if (EXIT_SUCCESS == $self->SUPER::setUp(%params)) {
-		$self->sut(Chleb->new({
-			dic => $self->_dic,
-		}));
+	if (EXIT_SUCCESS != $self->SUPER::setUp(%params)) {
+		return EXIT_FAILURE;
 	}
+
+	$self->sut(Chleb->new());
 
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Move the mock logger setup into Test::Module::Runnable::Local to avoid overhead