### PR TITLE
🥅 trap more invalid q= values in Accept header

### DIFF
--- a/lib/Chleb/Server/MediaType.pm
+++ b/lib/Chleb/Server/MediaType.pm
@@ -134,6 +134,8 @@ sub parseAcceptHeader {
 			if (my $className = blessed($evalError)) {
 				if ($className eq 'Moose::Exception::ValidationFailedForTypeConstraint') {
 					die Chleb::Exception->raise(HTTP_NOT_ACCEPTABLE, __extractMessageFromMooseException($evalError))
+				} elsif ($evalError->isa('Chleb::Exception')) {
+					die($evalError);
 				} else {
 					die Chleb::Exception->raise(HTTP_NOT_ACCEPTABLE, $className);
 				}

--- a/lib/Chleb/Server/MediaType.pm
+++ b/lib/Chleb/Server/MediaType.pm
@@ -138,7 +138,8 @@ sub parseAcceptHeader {
 					die Chleb::Exception->raise(HTTP_NOT_ACCEPTABLE, $className);
 				}
 			} else { # older Moose versions
-				die Chleb::Exception->raise(HTTP_NOT_ACCEPTABLE, 'Accept: incomplete spec');
+				chomp($evalError);
+				die Chleb::Exception->raise(HTTP_NOT_ACCEPTABLE, "Accept: ${evalError}");
 			}
 		}
 

--- a/lib/Chleb/Server/MediaType/Item.pm
+++ b/lib/Chleb/Server/MediaType/Item.pm
@@ -122,6 +122,8 @@ We check that the value does not have too much precison.
 sub __triggerWeight {
 	my ($self) = @_;
 
+	die(sprintf("negative qValue, %.3f\n", $self->weight)) if ($self->weight < 0);
+
 	my $str4 = sprintf('%.4f', abs($self->weight));
 	my $str3 = sprintf('%.3f', abs($self->weight));
 

--- a/lib/Chleb/Server/MediaType/Item.pm
+++ b/lib/Chleb/Server/MediaType/Item.pm
@@ -74,12 +74,11 @@ has [qw(major minor)] => (is => 'ro', required => 1, isa => 'Part');
 =item C<weight>
 
 The weight, whose default is always 1.0.  Lower values indicate a backup priority only.
-
-TODO: 1.1 and above is illegal, I think?  Check the standards.
+Valid values are between 0.000 and 1.000.  Greater precisions are not permitted.
 
 =cut
 
-has weight => (is => 'ro', required => 1, isa => 'Num', default => 1.0, required => 1);
+has weight => (is => 'ro', required => 1, isa => 'Num', default => 1.0, required => 1, trigger => \&__triggerWeight);
 
 =back
 
@@ -101,11 +100,36 @@ sub toString {
 
 	my $str = join('/', $self->major, $self->minor);
 
-	$str .= sprintf(';q=%.1f', $self->weight)
+	$str .= sprintf(';q=%.3f', $self->weight)
 	    if ($args->verbose);
 
 	return $str;
 }
+
+=back
+
+=head1 PRIVATE METHODS
+
+=over
+
+=item C<__triggerWeight>
+
+Special handler for accesses to L</weight>.
+We check that the value does not have too much precison.
+
+=cut
+
+sub __triggerWeight {
+	my ($self) = @_;
+
+	my $str4 = sprintf('%.4f', abs($self->weight));
+	my $str3 = sprintf('%.3f', abs($self->weight));
+
+	my $v = $str4 - $str3;
+	die("weight (qValue) precisions are limited to 3 digits\n") if ($v > 0);
+
+	return;
+};
 
 =back
 

--- a/lib/Chleb/Server/MediaType/Item.pm
+++ b/lib/Chleb/Server/MediaType/Item.pm
@@ -116,8 +116,10 @@ sub toString {
 
 =item C<__triggerWeight>
 
-Special handler for accesses to L</weight>.
-We check that the value does not have too much precison.
+Special trap handler for initial set of L</weight>.
+
+We check that the value does not have too much precison, and is a positive number,
+including zero, if not we die with a L<Chleb::Exception>.
 
 =cut
 

--- a/lib/Chleb/Server/MediaType/Item.pm
+++ b/lib/Chleb/Server/MediaType/Item.pm
@@ -33,6 +33,8 @@ use Moose;
 use strict;
 use warnings;
 
+use HTTP::Status qw(:constants);
+
 =head1 NAME
 
 Chleb::Server::MediaType::Item
@@ -122,13 +124,15 @@ We check that the value does not have too much precison.
 sub __triggerWeight {
 	my ($self) = @_;
 
-	die(sprintf("negative qValue, %.3f\n", $self->weight)) if ($self->weight < 0);
+	die Chleb::Exception->raise(HTTP_NOT_ACCEPTABLE, sprintf("Accept: negative qValue, %.3f", $self->weight))
+	    if ($self->weight < 0);
 
 	my $str4 = sprintf('%.4f', abs($self->weight));
 	my $str3 = sprintf('%.3f', abs($self->weight));
 
 	my $v = $str4 - $str3;
-	die("weight (qValue) precisions are limited to 3 digits\n") if ($v > 0);
+	die Chleb::Exception->raise(HTTP_NOT_ACCEPTABLE, 'Accept: weight (qValue) precisions are limited to 3 digits')
+	    if ($v > 0);
 
 	return;
 };

--- a/lib/Chleb/Server/MediaType/Item.pm
+++ b/lib/Chleb/Server/MediaType/Item.pm
@@ -129,12 +129,10 @@ sub __triggerWeight {
 	die Chleb::Exception->raise(HTTP_NOT_ACCEPTABLE, sprintf("Accept: negative qValue, %.3f", $self->weight))
 	    if ($self->weight < 0);
 
-	my $str4 = sprintf('%.4f', abs($self->weight));
-	my $str3 = sprintf('%.3f', abs($self->weight));
+	my (undef, $mantissa) = split(m/\./, $self->weight);
 
-	my $v = $str4 - $str3;
 	die Chleb::Exception->raise(HTTP_NOT_ACCEPTABLE, 'Accept: weight (qValue) precisions are limited to 3 digits')
-	    if ($v > 0);
+	    if (defined($mantissa) && length($mantissa) > 3);
 
 	return;
 };

--- a/t/Server_MediaType.t
+++ b/t/Server_MediaType.t
@@ -380,6 +380,33 @@ sub testMalformed {
 	return EXIT_SUCCESS;
 }
 
+sub testOverPrecision {
+	my ($self) = @_;
+
+	my $input = 'text/html;q=0.5001';
+
+	eval {
+		Chleb::Server::MediaType->parseAcceptHeader($input);
+	};
+
+	if (my $evalError = $EVAL_ERROR) {
+		my $description = 'Accept: weight (qValue) precisions are limited to 3 digits';
+		cmp_deeply($evalError, all(
+			isa('Chleb::Exception'),
+			methods(
+				description => re(qr/^\Q$description/),
+				location    => undef,
+				statusCode  => 406,
+			),
+		), "'${input}': ${description}");
+	} else {
+		fail("'${input}': No exception raised, as was expected");
+	}
+
+
+	return EXIT_SUCCESS;
+}
+
 package main;
 use strict;
 use warnings;

--- a/t/Server_MediaType.t
+++ b/t/Server_MediaType.t
@@ -407,6 +407,32 @@ sub testOverPrecision {
 	return EXIT_SUCCESS;
 }
 
+sub testNegative {
+	my ($self) = @_;
+
+	my $input = 'text/html;q=-0.1';
+
+	eval {
+		Chleb::Server::MediaType->parseAcceptHeader($input);
+	};
+
+	if (my $evalError = $EVAL_ERROR) {
+		my $description = 'Accept: negative qValue, -0.100';
+		cmp_deeply($evalError, all(
+			isa('Chleb::Exception'),
+			methods(
+				description => re(qr/^$description/),
+				location    => undef,
+				statusCode  => 406,
+			),
+		), "'${input}': ${description}");
+	} else {
+		fail("'${input}': No exception raised, as was expected");
+	}
+
+	return EXIT_SUCCESS;
+}
+
 package main;
 use strict;
 use warnings;

--- a/t/Server_MediaType.t
+++ b/t/Server_MediaType.t
@@ -383,7 +383,7 @@ sub testMalformed {
 sub testOverPrecision {
 	my ($self) = @_;
 
-	my $input = 'text/html;q=0.5001';
+	my $input = 'text/html;q=8.005001';
 
 	eval {
 		Chleb::Server::MediaType->parseAcceptHeader($input);


### PR DESCRIPTION
Trap illegal q= values in Accept headers, such as negative numbers, and the those of illegal precision (three digits maximum).  We now support throwing proper Chleb::Exception from Item, rather than relying on die.  We can't really change that for the "message" element within the Moose attribute, as the throw is handled by Moose.