### PR TITLE
🐛 re-open logs using SIGHUP from logrotate

### DIFF
--- a/etc/logrotate/chleb-bible-search
+++ b/etc/logrotate/chleb-bible-search
@@ -3,4 +3,9 @@
 	rotate 12
 	compress
 	delaycompress
+	missingok
+	notifempty
+	postrotate
+		/usr/bin/systemctl kill -s HUP --kill-who=all chleb-bible-search.service
+	endscript
 }

--- a/lib/Chleb/DI/Container.pm
+++ b/lib/Chleb/DI/Container.pm
@@ -66,7 +66,7 @@ Otherwise, you should replace it with L<Chleb::DI::MockLogger> during a test.
 
 =cut
 
-has logger => (is => 'rw', lazy => 1, builder => '_makeLogger');
+has logger => (is => 'rw', lazy => 1, builder => '_makeLogger', clearer => 'resetLogger');
 
 =item C<config>
 

--- a/lib/Chleb/Server.pm
+++ b/lib/Chleb/Server.pm
@@ -1194,6 +1194,17 @@ get '/1/info' => sub {
 
 $server = Chleb::Server->new();
 
+# Trap SIGHUP
+local $SIG{HUP} = sub {
+	eval {
+		$server->dic->resetLogger();
+		$server->dic->logger->debug('Received SIGHUP, re-opening logs');
+	};
+	if (my $evalError = $EVAL_ERROR) {
+		$server->dic->logger->error($evalError);
+	}
+};
+
 unless (caller()) {
 	$0 = 'chleb-bible-search [server]';
 	$server->title();


### PR DESCRIPTION
Need to re-open logs or we start writing to the file which has been rotated.