### PR TITLE
🚑️ added blank string default for IP address / user agent

### DIFF
--- a/lib/Chleb/Server/Moose.pm
+++ b/lib/Chleb/Server/Moose.pm
@@ -1122,8 +1122,8 @@ sub handleSessionToken {
 	}
 
 	my $request = Chleb::Server::Dancer2::_request();
-	my $ipAddress = $request->address();
-	my $userAgent = $request->agent();
+	my $ipAddress = $request->address() // '';
+	my $userAgent = $request->agent() // '';
 
 	my $tokenRepo = $self->dic->tokenRepo;
 	my $sessionToken;


### PR DESCRIPTION
Due to using sockets, the IP address and user agent may well be blank, don't assume they should be set.