### PR TITLE
🔨 add an iteration number on to new branches

### DIFF
--- a/bin/git/tools/newbranch
+++ b/bin/git/tools/newbranch
@@ -147,7 +147,8 @@ case "$branchType" in
 		;;
 esac
 
-fullBranchName="${branchType}/${branchName}"
+iteration=1
+fullBranchName="${branchType}/${branchName}/${iteration}"
 echo "${fullBranchName}"
 
 git stash push


### PR DESCRIPTION
If you need to branch off a branch then use /2
The trouble is, if we try to use /2 and there is no /1, Git gives us an obscure error.  So plan for this!