### PR TITLE
😈 FreeBSD platform; don't rely on dpkg for version parse

### DIFF
--- a/bin/maint/pkg-info.sh
+++ b/bin/maint/pkg-info.sh
@@ -29,6 +29,24 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+# this function mimics dpkg-parsechangelog --show-field Version
+# so we can generate the version number on FreeBSD or where the
+# Debian toolchain is not available, or it isn't work installing
+# for our purposes.
+
+set -e
+
+dpkg_parsechangelog_version() {
+	local changelog='debian/changelog'
+	if [ ! -f "$changelog" ]; then
+		echo "ERROR: $changelog not found" >&2
+		return 1
+	fi
+
+	# Print version from first line of changelog
+	head -n1 "$changelog" | sed -E 's/^[^(]*\(([^)]*)\).*/\1/'
+}
+
 outFile='lib/Chleb/Generated/Info.pm'
 
 buildUser=$(whoami)
@@ -37,7 +55,7 @@ buildOS=$(uname -o)
 buildArch=$(uname -m)
 buildTime=$(date '+%Y-%m-%dT%H:%M:%S%z')
 buildPerlVersion=$(perl -e 'print "$^V ($])"')
-version=$(dpkg-parsechangelog --show-field Version)
+version=$(dpkg_parsechangelog_version)
 
 buildChangeset=''
 if [ -f '.git-changeset' ]; then

--- a/bin/maint/pkg-info.sh
+++ b/bin/maint/pkg-info.sh
@@ -31,19 +31,31 @@
 
 set -e
 
-# this function mimics dpkg-parsechangelog --show-field Version
-# so we can generate the version number on FreeBSD or where the
-# Debian toolchain is not available, or it isn't work installing
-# for our purposes.
+# Parses the given Debian changelog file to extract the version number.
+# Mimics the behavior of `dpkg-parsechangelog --show-field Version`.
+# Arguments:
+#   $1 - The path to the Debian changelog file.
+# Returns:
+#   The extracted version number, or an error message if the version number could not be extracted.
 dpkg_parsechangelog_version() {
-	local changelog='debian/changelog'
-	if [ ! -f "$changelog" ]; then
-		echo "ERROR: $changelog not found" >&2
+	local changelog="$1"
+
+	# Check if the changelog file exists and is readable.
+	if [[ ! -r "$changelog" ]]; then
+		echo "ERROR: Cannot read the changelog file: $changelog" >&2
 		return 1
 	fi
 
-	# Print version from first line of changelog
-	head -n1 "$changelog" | sed -E 's/^[^(]*\(([^)]*)\).*/\1/'
+	# Use awk to process the file line by line.
+	local version_line=$(head -n1 "$changelog" | sed -E 's/^[^(]*\(([^)]*)\).*/\1/')
+
+	# Check if the version line was found.
+	if [[ -z "$version_line" ]]; then
+		echo "ERROR: Could not find the version line in the changelog file: $changelog" >&2
+		return 1
+	fi
+
+	echo "$version_line"
 }
 
 outFile='lib/Chleb/Generated/Info.pm'
@@ -54,7 +66,7 @@ buildOS=$(uname -o)
 buildArch=$(uname -m)
 buildTime=$(date '+%Y-%m-%dT%H:%M:%S%z')
 buildPerlVersion=$(perl -e 'print "$^V ($])"')
-version=$(dpkg_parsechangelog_version) || exit 1
+version=$(dpkg_parsechangelog_version debian/changelog) || exit 1
 
 buildChangeset=''
 if [ -f '.git-changeset' ]; then

--- a/bin/maint/pkg-info.sh
+++ b/bin/maint/pkg-info.sh
@@ -29,13 +29,12 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+set -e
+
 # this function mimics dpkg-parsechangelog --show-field Version
 # so we can generate the version number on FreeBSD or where the
 # Debian toolchain is not available, or it isn't work installing
 # for our purposes.
-
-set -e
-
 dpkg_parsechangelog_version() {
 	local changelog='debian/changelog'
 	if [ ! -f "$changelog" ]; then

--- a/bin/maint/pkg-info.sh
+++ b/bin/maint/pkg-info.sh
@@ -54,7 +54,7 @@ buildOS=$(uname -o)
 buildArch=$(uname -m)
 buildTime=$(date '+%Y-%m-%dT%H:%M:%S%z')
 buildPerlVersion=$(perl -e 'print "$^V ($])"')
-version=$(dpkg_parsechangelog_version)
+version=$(dpkg_parsechangelog_version) || exit 1
 
 buildChangeset=''
 if [ -f '.git-changeset' ]; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

Based on the summary of changes, it seems like you've made some improvements to your shell script. However, without seeing the actual code, I can only provide general advice.

1. **Logic:** Ensure that your new function `dpkg_parsechangelog_version` correctly parses the version number from the Debian changelog file. It should handle all possible formats and edge cases.

2. **Performance:** If the `dpkg-parsechangelog` command was replaced because it was slow or resource-intensive, make sure your new function is more efficient. You could do this by minimizing disk I/O operations, reducing unnecessary string manipulations, etc.

3. **Error Handling:** Your new function should have proper error handling. For instance, what happens if the changelog file doesn't exist, or if it's in an unexpected format? The function should return meaningful error messages in these cases.

4. **Maintainability:** Make sure your new function is easy to understand and modify. Use clear variable names, avoid magic numbers, and consider adding comments explaining the logic, especially if it's complex.

5. **Consistency:** If there are other places in your code where you're parsing Debian changelog files, consider using your new function there as well to keep things consistent.

6. **Best Practices:** Follow best practices for shell scripting. For example, use `"$var"` instead of `$var` to prevent word splitting and pathname expansion, and prefer `[[ ]]` over `[ ]` for tests.

Again, these are just general suggestions. If you provide the actual code, I can give more specific advice.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->