### PR TITLE
🐛 Wholeword not picking up words containing punctuation

### DIFF
--- a/lib/Chleb/Bible/Book.pm
+++ b/lib/Chleb/Bible/Book.pm
@@ -247,11 +247,17 @@ sub search {
 			my $found = 0;
 
 			if ($query->wholeword) {
-				$found = 1 if ($text =~ m/\s+$critereonText,/i);
-				$found = 1 if ($text =~ m/\s+$critereonText:/i);
-				$found = 1 if ($text =~ m/\s+$critereonText;/i);
-				$found = 1 if ($text =~ m/^$critereonText\s+/i);
-				$found = 1 if ($text =~ m/\s+$critereonText\s+/i);
+				my @words = split(m/\s+/, $text);
+				foreach my $word (@words) {
+					if (lc($word) eq lc($critereonText)) {
+						$found = 1;
+						last;
+					}
+				}
+				if ($found == 0) {
+					@words = grep { /^$critereonText[\s\.,:;-]/i } @words;
+					$found = (scalar(@words) > 0);
+				}
 			} else {
 				$found = 1 if ($text =~ m/$critereonText/i);
 			}

--- a/lib/Chleb/Bible/Book.pm
+++ b/lib/Chleb/Bible/Book.pm
@@ -238,7 +238,8 @@ sub search {
 
 	my $rx;
 	if ($query->wholeword) {
-		$rx = qr/^$critereonText(?:[\s\.,:;-]|$)/i;
+		my $safe = quotemeta($critereonText);
+		$rx = qr/^$safe(?:[\s.,:;()?!-]|$)/i;
 	} else {
 		$rx = qr/$critereonText/i;
 	}

--- a/lib/Chleb/Bible/Book.pm
+++ b/lib/Chleb/Bible/Book.pm
@@ -248,16 +248,8 @@ sub search {
 
 			if ($query->wholeword) {
 				my @words = split(m/\s+/, $text);
-				foreach my $word (@words) {
-					if (lc($word) eq lc($critereonText)) {
-						$found = 1;
-						last;
-					}
-				}
-				if ($found == 0) {
-					@words = grep { /^$critereonText[\s\.,:;-]/io } @words;
-					$found = (scalar(@words) > 0);
-				}
+				@words = grep { /^$critereonText([\s\.,:;-]|$)/i } @words;
+				$found = (scalar(@words) > 0);
 			} else {
 				$found = 1 if ($text =~ m/$critereonText/i);
 			}

--- a/lib/Chleb/Bible/Book.pm
+++ b/lib/Chleb/Bible/Book.pm
@@ -235,6 +235,14 @@ sub search {
 	my @verses;
 
 	my $critereonText = $query->text;
+
+	my $rx;
+	if ($query->wholeword) {
+		$rx = qr/^$critereonText(?:[\s\.,:;-]|$)/i;
+	} else {
+		$rx = qr/$critereonText/i;
+	}
+
 	CHAPTER: for (my $chapterOrdinal = 1; $chapterOrdinal <= $self->chapterCount; $chapterOrdinal++) {
 		my $chapter = $self->getChapterByOrdinal($chapterOrdinal);
 
@@ -247,9 +255,9 @@ sub search {
 
 			my $found;
 			if ($query->wholeword) {
-				$found = grep { /^$critereonText(?:[\s\.,:;-]|$)/i } split(m/\s+/, $text);
+				$found = grep { m/$rx/ } split(m/\s+/, $text);
 			} else {
-				$found = ($text =~ m/$critereonText/i);
+				$found = ($text =~ m/$rx/);
 			}
 
 			push(@verses, Chleb::Bible::Verse->new({

--- a/lib/Chleb/Bible/Book.pm
+++ b/lib/Chleb/Bible/Book.pm
@@ -244,14 +244,12 @@ sub search {
 			# but you need some more methods in the library to avoid it
 			# Perhaps have a getVerseByKey in _library?
 			my $text = $self->bible->__backend->getVerseDataByKey($verseKey);
-			my $found = 0;
 
+			my $found;
 			if ($query->wholeword) {
-				my @words = split(m/\s+/, $text);
-				@words = grep { /^$critereonText([\s\.,:;-]|$)/i } @words;
-				$found = (scalar(@words) > 0);
+				$found = grep { /^$critereonText(?:[\s\.,:;-]|$)/i } split(m/\s+/, $text);
 			} else {
-				$found = 1 if ($text =~ m/$critereonText/i);
+				$found = ($text =~ m/$critereonText/i);
 			}
 
 			push(@verses, Chleb::Bible::Verse->new({

--- a/lib/Chleb/Bible/Book.pm
+++ b/lib/Chleb/Bible/Book.pm
@@ -238,8 +238,8 @@ sub search {
 
 	my $rx;
 	if ($query->wholeword) {
-		my $safe = quotemeta($critereonText);
-		$rx = qr/^$safe(?:[\s.,:;()?!-]|$)/i;
+		$critereonText = quotemeta($critereonText);
+		$rx = qr/^$critereonText(?:[\s.,:;()?!-]|$)/i;
 	} else {
 		$rx = qr/$critereonText/i;
 	}

--- a/lib/Chleb/Bible/Book.pm
+++ b/lib/Chleb/Bible/Book.pm
@@ -255,7 +255,7 @@ sub search {
 					}
 				}
 				if ($found == 0) {
-					@words = grep { /^$critereonText[\s\.,:;-]/i } @words;
+					@words = grep { /^$critereonText[\s\.,:;-]/io } @words;
 					$found = (scalar(@words) > 0);
 				}
 			} else {

--- a/t/Server_search.t
+++ b/t/Server_search.t
@@ -403,6 +403,24 @@ sub test {
 	return EXIT_SUCCESS;
 }
 
+sub testWholeWordPunctuation {
+	my ($self) = @_;
+	plan tests => 1;
+
+	my $term = 'pricks';
+	my $mediaType = Chleb::Server::MediaType->parseAcceptHeader('application/json');
+	my $json = $self->sut->__search({
+		accept => $mediaType,
+		limit => 2,
+		term => $term,
+		wholeword => 'true',
+	});
+
+	is(scalar(@{ $json->{data} }), 2, 'two results, as expected');
+
+	return EXIT_SUCCESS;
+}
+
 __PACKAGE__->meta->make_immutable;
 
 package main;

--- a/t/Server_search.t
+++ b/t/Server_search.t
@@ -405,7 +405,7 @@ sub test {
 
 sub testWholeWordPunctuation {
 	my ($self) = @_;
-	plan tests => 1;
+	plan tests => 3;
 
 	my $term = 'pricks';
 	my $mediaType = Chleb::Server::MediaType->parseAcceptHeader('application/json');
@@ -417,6 +417,12 @@ sub testWholeWordPunctuation {
 	});
 
 	is(scalar(@{ $json->{data} }), 2, 'two results, as expected');
+
+	# assertions to verify the content of the results
+	my $counter = 0;
+	foreach my $result (@{ $json->{data} }) {
+		like($result->{attributes}->{text}, qr/\b$term\b/, sprintf("Result (%d/2) text contains the term '%s'", ++$counter, $term));
+	}
 
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Re-write the whole-word search algorithm



<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

The changes you've made seem to be well thought out and are likely to improve the overall quality of the code. Here are some suggestions based on your summary:

1. **README.md**: The change in the installation process is a good step towards improving readability. However, consider adding error handling or checks after each installation step. This way, if one installation fails, the user will be notified immediately rather than after all installations have been attempted.

2. **lib/Chleb/Bible/Book.pm**: Refactoring the whole-word search algorithm to handle punctuation is a great improvement. However, ensure that this new logic doesn't introduce any performance issues, especially when dealing with large texts. Consider benchmarking the old and new methods to compare their performance.

3. **t/Server_search.t**: Adding tests for new functionality is always a good practice. Make sure that your new test `testWholeWordPunctuation` covers various edge cases, such as words at the beginning or end of sentences, words adjacent to different types of punctuation, and so on. Also, consider adding negative tests where the expected result is not finding a match.

4. **General**: Ensure that these changes do not break any existing functionality. Run all existing tests after making these changes and fix any breaking changes. If there are no existing tests, consider adding them to ensure the stability of your application.

Remember, while refactoring and adding new features, it's important to keep an eye on potential impacts on performance, maintainability, and compatibility with existing code.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->