### PR TITLE
 #🚑️ create RunTimeDirectory via systemd

### DIFF
--- a/etc/chleb-bible-search.service
+++ b/etc/chleb-bible-search.service
@@ -16,6 +16,8 @@ Nice=15
 Restart=always
 User=chleb
 UMask=000
+RuntimeDirectory=chleb-bible-search
+RuntimeDirectoryMode=0755
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This problem stops the service starting on boot unless the package is re-installed.  Demonstrating we have a low-base in terms of customers installing their own daemon, because it would not have worked, unless people work around it.

For issue #146 
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

The summary of changes provided seems to be related to a systemd service unit file. The changes include adding `RuntimeDirectory=chleb-bible-search` and `RuntimeDirectoryMode=0755`. 

Here's a brief explanation of these changes:

- `RuntimeDirectory=chleb-bible-search`: This directive specifies the name of a runtime directory to be created before the service is started. Systemd will create and set the ownership of this directory to the user and group specified in the service file.

- `RuntimeDirectoryMode=0755`: This directive sets the access mode (permissions) of the runtime directory specified above. In this case, it's set to 0755, which means the owner can read, write, and execute, while others can only read and execute.

These changes are generally made to ensure that the service has its own private runtime directory with the correct permissions, which is a good practice for security and isolation reasons. However, without seeing the rest of the service unit file or knowing more about the application, it's hard to provide a more specific review. 

If you have any specific questions or if there's more code to review, feel free to share!
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->