### PR TITLE
🚸 Improve VoTD by including reverse context

### DIFF
--- a/lib/Chleb.pm
+++ b/lib/Chleb.pm
@@ -249,6 +249,11 @@ sub votd {
 		$self->dic->logger->debug('Skipping ' . $verse->toString() . ' because of parental mode');
 	}
 
+	while ($verse->previous && $verse->previous->continues) {
+		# look upwards until we are not on a continuation, to give increased context
+		$verse = $verse->previous;
+	}
+
 	$self->dic->logger->debug($verse->toString());
 
 	my $msecAll = 0;

--- a/lib/Chleb.pm
+++ b/lib/Chleb.pm
@@ -271,10 +271,10 @@ sub votd {
 				$msec = int(1000 * ($endTiming - $startTiming));
 				$verse->[-1]->msec($msec);
 				$msecAll += $msec;
-				$startTiming = Time::HiRes::time();
+				$startTiming = Time::HiRes::time() unless (defined($startTiming));
 			}
 
-			$startTiming = Time::HiRes::time();
+			$startTiming = Time::HiRes::time() unless (defined($startTiming));
 		}
 	} else {
 		my $endTiming = Time::HiRes::time();

--- a/lib/Chleb/Bible/Verse.pm
+++ b/lib/Chleb/Bible/Verse.pm
@@ -61,6 +61,8 @@ has parental => (is => 'ro', isa => 'Str', lazy => 1, default => \&__makeParenta
 
 has key => (is => 'ro', isa => 'Str', lazy => 1, default => \&__makeKey);
 
+has previous => (is => 'ro', isa => 'Maybe[Chleb::Bible::Verse]', lazy => 1, init_arg => undef, builder => 'getPrev');
+
 has __sentiment => (is => 'ro', isa => 'HashRef', lazy => 1, init_arg => undef, default => \&__makeSentiment);
 
 sub BUILD {

--- a/t/Server_votd.t
+++ b/t/Server_votd.t
@@ -176,6 +176,44 @@ sub testV2 {
 					book => 'num',
 					chapter => 33,
 					emotion => 'neutral',
+					ordinal => 50,
+					text => 'And the LORD spake unto Moses in the plains of Moab by Jordan [near] Jericho, saying,',
+					tones => [
+						'instruction',
+					],
+					translation => 'kjv',
+				},
+				id => 'kjv/num/33/50',
+				links => {
+					first => '/1/lookup/num/33/1',
+					last => '/1/lookup/num/33/56',
+					next => '/1/lookup/num/33/51',
+					prev => '/1/lookup/num/33/49',
+					self => '/1/lookup/num/33/50',
+				},
+				relationships => {
+					book => {
+						data => {
+							id => 'kjv/num',
+							type => 'book',
+						},
+						links => {},
+					},
+					chapter => {
+						data => {
+							id => 'kjv/num/33',
+							type => 'chapter',
+						},
+						links => {},
+					},
+				},
+				type => 'verse',
+			},
+			{
+				attributes => {
+					book => 'num',
+					chapter => 33,
+					emotion => 'neutral',
 					ordinal => 51,
 					text => 'Speak unto the children of Israel, and say unto them, When ye are passed over Jordan into the land of Canaan;',
 					tones => ['instruction'],

--- a/t/votd.t
+++ b/t/votd.t
@@ -87,6 +87,15 @@ sub testV2 {
 			methods(
 				book    => isa('Chleb::Bible::Book'),
 				chapter => isa('Chleb::Bible::Chapter'),
+				ordinal => 50,
+				text    => 'And the LORD spake unto Moses in the plains of Moab by Jordan [near] Jericho, saying,',
+			),
+		),
+		all(
+			isa('Chleb::Bible::Verse'),
+			methods(
+				book    => isa('Chleb::Bible::Book'),
+				chapter => isa('Chleb::Bible::Chapter'),
 				ordinal => 51,
 				text    => 'Speak unto the children of Israel, and say unto them, When ye are passed over Jordan into the land of Canaan;',
 			),
@@ -185,7 +194,7 @@ sub testParentalRef {
 				isa('Chleb::Bible::Chapter'),
 				methods(ordinal => 22),
 			),
-			ordinal => 21,
+			ordinal => 20,
 			text    => ignore(),
 		),
 	), 'verse inspection') or diag(explain($verse->toString()));
@@ -206,7 +215,7 @@ sub testParentalRef {
 				isa('Chleb::Bible::Chapter'),
 				methods(ordinal => 37),
 			),
-			ordinal => 19,
+			ordinal => 18,
 			text    => ignore(),
 		),
 	), 'verse inspection, parental') or diag(explain($verse->toString()));


### PR DESCRIPTION
When the previous verse has a continuation, we'll include it.

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

Based on the summary of changes, here are my suggestions:

1. `lib/Chleb.pm`: 
   - For the initialization of `$startTiming`, consider using a ternary operator or a short-circuit logical OR to simplify the code and improve readability.
   - When adding a loop to include the previous verse context, ensure that you're not introducing an infinite loop. Also, consider the performance implications if the context is very large.
   - For handling undefined `startTiming`, it's good to have error checking in place. However, also consider why `startTiming` might be undefined and whether this indicates a deeper issue in your code.

2. `lib/Chleb/Bible/Verse.pm`: 
   - Adding a new attribute `previous` with lazy initialization is a good idea for performance reasons. However, make sure to handle cases where the `previous` attribute is not yet initialized and is being accessed.

3. `t/Server_votd.t`: 
   - When adding a new verse to the JSON response in the `testV2` function, ensure that the JSON structure remains valid. Also, update any functions that parse this JSON response to handle the new verse.

4. `t/votd.t`: 
   - When adding a new verse with reverse context in the test case for `testV2`, ensure that the test case correctly checks the presence and correctness of this reverse context.
   - Adjusting ordinals in the test cases `testParentalRef` from 21 to 20 and 19 to 18 should be fine as long as it aligns with the expected behavior of the function under test.

Remember to thoroughly test all these changes to ensure they work as expected and don't introduce new bugs.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->