### PR TITLE
🔗 superscripts link to exact verses

### DIFF
--- a/lib/Chleb/Server/Moose.pm
+++ b/lib/Chleb/Server/Moose.pm
@@ -876,14 +876,17 @@ sub __verseToHtml {
 	my $reference;
 	for (my $verseIndex = 0; $verseIndex < $verseCount; $verseIndex++) {
 		my $attributes = $json->[0]->{data}->[$verseIndex]->{attributes};
-		my $bookName = $rawBookNameMap{ $attributes->{book} };
+		my $bookName = $attributes->{book};
+		my $bookNameRaw = $rawBookNameMap{$bookName};
 		my $chapter = $attributes->{chapter};
 		my $verseOrdinal = $attributes->{ordinal};
 
 		if ($verseIndex == 0) {
-			$reference = sprintf('%s %d:%d', $bookName, $chapter, $verseOrdinal);
+			$reference = sprintf('%s %d:%d', $bookNameRaw, $chapter, $verseOrdinal);
 		} else {
+			$output .= sprintf('<a href="/1/lookup/%s/%d/%d"', $bookName, $chapter, $verseOrdinal);
 			$output .= "<sup class=\"versenum\">${verseOrdinal} </sup>";
+			$output .= '</a>';
 		}
 
 		$output .= $attributes->{text};


### PR DESCRIPTION
The small verse numbers here, in a wider viewing, will take you to the exact verse lookup
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

The summary of changes provided seems to be clear and concise. It explains what was done in the update, specifically mentioning that the code now uses the raw book name from the map for generating the reference link and an anchor tag has been added around the verse number to create a link to the exact verse lookup.

However, without the actual code, it's hard to provide a thorough review or suggest improvements. If you have any specific code snippets related to these changes, please share them so I can provide a more detailed analysis and suggestions.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->