### PR TITLE
📄 Copyright bump 2026

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,5 +1,5 @@
 Chleb Bible Search
-Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/core/app.psgi
+++ b/bin/core/app.psgi
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/core/run.sh
+++ b/bin/core/run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/core/session-clean.sh
+++ b/bin/core/session-clean.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/core/session-dump.pl
+++ b/bin/core/session-dump.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/core/votd-mailer.sh
+++ b/bin/core/votd-mailer.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/core/yaml2json.pl
+++ b/bin/core/yaml2json.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/demo/john.pl
+++ b/bin/demo/john.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/demo/server-info.sh
+++ b/bin/demo/server-info.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/demo/server-lookup.sh
+++ b/bin/demo/server-lookup.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/demo/server-ping.sh
+++ b/bin/demo/server-ping.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/demo/server-random.sh
+++ b/bin/demo/server-random.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/demo/server-search.sh
+++ b/bin/demo/server-search.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/demo/server-uptime.sh
+++ b/bin/demo/server-uptime.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/demo/server-version.sh
+++ b/bin/demo/server-version.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/demo/server-votd.sh
+++ b/bin/demo/server-votd.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/demo/server-walk-book-reverse.sh
+++ b/bin/demo/server-walk-book-reverse.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/demo/server-walk-book.sh
+++ b/bin/demo/server-walk-book.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/demo/socket-info.sh
+++ b/bin/demo/socket-info.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/demo/socket-lookup.sh
+++ b/bin/demo/socket-lookup.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/demo/socket-ping.sh
+++ b/bin/demo/socket-ping.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/demo/socket-random.sh
+++ b/bin/demo/socket-random.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/demo/socket-search.sh
+++ b/bin/demo/socket-search.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/demo/socket-uptime.sh
+++ b/bin/demo/socket-uptime.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/demo/socket-version.sh
+++ b/bin/demo/socket-version.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/demo/socket-votd.sh
+++ b/bin/demo/socket-votd.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/demo/socket-walk-book-reverse.sh
+++ b/bin/demo/socket-walk-book-reverse.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/demo/socket-walk-book.sh
+++ b/bin/demo/socket-walk-book.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/demo/votd.pl
+++ b/bin/demo/votd.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/export/to-flat-json.pl
+++ b/bin/export/to-flat-json.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/git/hooks/post-checkout
+++ b/bin/git/hooks/post-checkout
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/git/hooks/post-commit
+++ b/bin/git/hooks/post-commit
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/git/tools/mergebranch
+++ b/bin/git/tools/mergebranch
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/git/tools/mergepreview
+++ b/bin/git/tools/mergepreview
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/git/tools/newbranch
+++ b/bin/git/tools/newbranch
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/import/text-to-asv.sh
+++ b/bin/import/text-to-asv.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/import/text-to-bin.pl
+++ b/bin/import/text-to-bin.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/import/text-to-kjv.sh
+++ b/bin/import/text-to-kjv.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/maint/copyright-bump.sh
+++ b/bin/maint/copyright-bump.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-find lib/ -name "*.pm" -type f -exec sed -i 's/2024-2026/2024-2026/' {} \;
-find t/ -name "*.t" -type f -exec sed -i 's/2024-2026/2024-2026/' {} \;
-sed -i 's/2024-2026/2024-2026/' *.PL
-find bin -name "*.sh" -type f -exec sed -i 's/2024-2026/2024-2026/' {} \;
-find bin -name "*.pl" -type f -exec sed -i 's/2024-2026/2024-2026/' {} \;
-sed -i 's/2024-2026/2024-2026/' bitbucket-pipelines.yml COPYING data/Makefile debian/rules debian/copyright
+find lib/ -name "*.pm" -type f -exec sed -i 's/2024/2024-2025/' {} \;
+find t/ -name "*.t" -type f -exec sed -i 's/2024/2024-2025/' {} \;
+sed -i 's/2024/2024-2025/' *.PL
+find bin -name "*.sh" -type f -exec sed -i 's/2024/2024-2025/' {} \;
+find bin -name "*.pl" -type f -exec sed -i 's/2024/2024-2025/' {} \;
+sed -i 's/2024/2024-2025/' bitbucket-pipelines.yml COPYING data/Makefile debian/rules debian/copyright
 
 exit 0

--- a/bin/maint/copyright-bump.sh
+++ b/bin/maint/copyright-bump.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-find lib/ -name "*.pm" -type f -exec sed -i 's/2024/2024-2025/' {} \;
-find t/ -name "*.t" -type f -exec sed -i 's/2024/2024-2025/' {} \;
-sed -i 's/2024/2024-2025/' *.PL
-find bin -name "*.sh" -type f -exec sed -i 's/2024/2024-2025/' {} \;
-find bin -name "*.pl" -type f -exec sed -i 's/2024/2024-2025/' {} \;
-sed -i 's/2024/2024-2025/' bitbucket-pipelines.yml COPYING data/Makefile debian/rules debian/copyright
+find lib/ -name "*.pm" -type f -exec sed -i 's/2024/2024-2026/' {} \;
+find t/ -name "*.t" -type f -exec sed -i 's/2024/2024-2026/' {} \;
+sed -i 's/2024/2024-2026/' *.PL
+find bin -name "*.sh" -type f -exec sed -i 's/2024/2024-2026/' {} \;
+find bin -name "*.pl" -type f -exec sed -i 's/2024/2024-2026/' {} \;
+sed -i 's/2024/2024-2026/' bitbucket-pipelines.yml COPYING data/Makefile debian/rules debian/copyright
 
 exit 0

--- a/bin/maint/copyright-bump.sh
+++ b/bin/maint/copyright-bump.sh
@@ -2,11 +2,12 @@
 
 set -e
 
-find lib/ -name "*.pm" -type f -exec sed -i 's/2024/2024-2026/' {} \;
-find t/ -name "*.t" -type f -exec sed -i 's/2024/2024-2026/' {} \;
-sed -i 's/2024/2024-2026/' *.PL
-find bin -name "*.sh" -type f -exec sed -i 's/2024/2024-2026/' {} \;
-find bin -name "*.pl" -type f -exec sed -i 's/2024/2024-2026/' {} \;
-sed -i 's/2024/2024-2026/' bitbucket-pipelines.yml COPYING data/Makefile debian/rules debian/copyright
+find lib/ -name "*.pm" -type f -exec sed -i 's/2025/2026/' {} \;
+find t/ -name "*.t" -type f -exec sed -i 's/2025/2026/' {} \;
+sed -i 's/2025/2026/' *.PL
+find bin -name "*.sh" -type f -exec sed -i 's/2025/2026/' {} \;
+find bin -name "*.pl" -type f -exec sed -i 's/2025/2026/' {} \;
+find data/tests -name "*.sh" -type f -exec sed -i 's/2025/2026/' {} \;
+sed -i 's/2025/2026/' bitbucket-pipelines.yml COPYING data/Makefile debian/rules debian/copyright
 
 exit 0

--- a/bin/maint/copyright-bump.sh
+++ b/bin/maint/copyright-bump.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-find lib/ -name "*.pm" -type f -exec sed -i 's/2024-2025/2024-2026/' {} \;
-find t/ -name "*.t" -type f -exec sed -i 's/2024-2025/2024-2026/' {} \;
-sed -i 's/2024-2025/2024-2026/' *.PL
-find bin -name "*.sh" -type f -exec sed -i 's/2024-2025/2024-2026/' {} \;
-find bin -name "*.pl" -type f -exec sed -i 's/2024-2025/2024-2026/' {} \;
-sed -i 's/2024-2025/2024-2026/' bitbucket-pipelines.yml COPYING data/Makefile debian/rules debian/copyright
+find lib/ -name "*.pm" -type f -exec sed -i 's/2024-2026/2024-2026/' {} \;
+find t/ -name "*.t" -type f -exec sed -i 's/2024-2026/2024-2026/' {} \;
+sed -i 's/2024-2026/2024-2026/' *.PL
+find bin -name "*.sh" -type f -exec sed -i 's/2024-2026/2024-2026/' {} \;
+find bin -name "*.pl" -type f -exec sed -i 's/2024-2026/2024-2026/' {} \;
+sed -i 's/2024-2026/2024-2026/' bitbucket-pipelines.yml COPYING data/Makefile debian/rules debian/copyright
 
 exit 0

--- a/bin/maint/copyright-bump.sh
+++ b/bin/maint/copyright-bump.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-find lib/ -name "*.pm" -type f -exec sed -i 's/2024/2024-2025/' {} \;
-find t/ -name "*.t" -type f -exec sed -i 's/2024/2024-2025/' {} \;
-sed -i 's/2024/2024-2025/' *.PL
-find bin -name "*.sh" -type f -exec sed -i 's/2024/2024-2025/' {} \;
-find bin -name "*.pl" -type f -exec sed -i 's/2024/2024-2025/' {} \;
-sed -i 's/2024/2024-2025/' bitbucket-pipelines.yml COPYING data/Makefile debian/rules debian/copyright
+find lib/ -name "*.pm" -type f -exec sed -i 's/2024-2025/2024-2026/' {} \;
+find t/ -name "*.t" -type f -exec sed -i 's/2024-2025/2024-2026/' {} \;
+sed -i 's/2024-2025/2024-2026/' *.PL
+find bin -name "*.sh" -type f -exec sed -i 's/2024-2025/2024-2026/' {} \;
+find bin -name "*.pl" -type f -exec sed -i 's/2024-2025/2024-2026/' {} \;
+sed -i 's/2024-2025/2024-2026/' bitbucket-pipelines.yml COPYING data/Makefile debian/rules debian/copyright
 
 exit 0

--- a/bin/maint/git-install-local-hooks.sh
+++ b/bin/maint/git-install-local-hooks.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/maint/make-legal-notices.sh
+++ b/bin/maint/make-legal-notices.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/maint/md2html.pl
+++ b/bin/maint/md2html.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/maint/pkg-info.sh
+++ b/bin/maint/pkg-info.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/maint/run-functional-tests.sh
+++ b/bin/maint/run-functional-tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bin/maint/swagger-check.sh
+++ b/bin/maint/swagger-check.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data.PL
+++ b/data.PL
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/Makefile
+++ b/data/Makefile
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/a HTML.sh
+++ b/data/tests/1/a HTML.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/a JSON.sh
+++ b/data/tests/1/a JSON.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/a.sh
+++ b/data/tests/1/a.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/info HTML.sh
+++ b/data/tests/1/info HTML.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/info JSON.sh
+++ b/data/tests/1/info JSON.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/info default.sh
+++ b/data/tests/1/info default.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/lookup HTML, redirect.sh
+++ b/data/tests/1/lookup HTML, redirect.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/lookup HTML.sh
+++ b/data/tests/1/lookup HTML.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/lookup JSON.sh
+++ b/data/tests/1/lookup JSON.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/lookup default.sh
+++ b/data/tests/1/lookup default.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/ping HTML.sh
+++ b/data/tests/1/ping HTML.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/ping JSON.sh
+++ b/data/tests/1/ping JSON.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/ping default.sh
+++ b/data/tests/1/ping default.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/random HTML, redirect.sh
+++ b/data/tests/1/random HTML, redirect.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/random HTML.sh
+++ b/data/tests/1/random HTML.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/random JSON, redirect.sh
+++ b/data/tests/1/random JSON, redirect.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/random JSON.sh
+++ b/data/tests/1/random JSON.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/random default, redirect.sh
+++ b/data/tests/1/random default, redirect.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/random default.sh
+++ b/data/tests/1/random default.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/search HTML 'dwell', form.sh
+++ b/data/tests/1/search HTML 'dwell', form.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/search HTML 'dwell'.sh
+++ b/data/tests/1/search HTML 'dwell'.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/search HTML (no criteria).sh
+++ b/data/tests/1/search HTML (no criteria).sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/search JSON 'fire', form.sh
+++ b/data/tests/1/search JSON 'fire', form.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/search JSON 'fire'.sh
+++ b/data/tests/1/search JSON 'fire'.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/search JSON (no criteria).sh
+++ b/data/tests/1/search JSON (no criteria).sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/search default 'son', form.sh
+++ b/data/tests/1/search default 'son', form.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/search default 'son'.sh
+++ b/data/tests/1/search default 'son'.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/search default (no criteria).sh
+++ b/data/tests/1/search default (no criteria).sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/template.sh
+++ b/data/tests/1/template.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/uptime HTML.sh
+++ b/data/tests/1/uptime HTML.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/uptime JSON.sh
+++ b/data/tests/1/uptime JSON.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/uptime default.sh
+++ b/data/tests/1/uptime default.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/version HTML.sh
+++ b/data/tests/1/version HTML.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/version JSON.sh
+++ b/data/tests/1/version JSON.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/version default.sh
+++ b/data/tests/1/version default.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/votd HTML, redirect.sh
+++ b/data/tests/1/votd HTML, redirect.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/votd HTML.sh
+++ b/data/tests/1/votd HTML.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/votd JSON, redirect.sh
+++ b/data/tests/1/votd JSON, redirect.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/votd JSON.sh
+++ b/data/tests/1/votd JSON.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/votd default, redirect.sh
+++ b/data/tests/1/votd default, redirect.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/1/votd default.sh
+++ b/data/tests/1/votd default.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/2/random HTML, redirect.sh
+++ b/data/tests/2/random HTML, redirect.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/2/random HTML.sh
+++ b/data/tests/2/random HTML.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/2/random JSON, redirect.sh
+++ b/data/tests/2/random JSON, redirect.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/2/random JSON.sh
+++ b/data/tests/2/random JSON.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/2/random default, redirect.sh
+++ b/data/tests/2/random default, redirect.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/2/random default.sh
+++ b/data/tests/2/random default.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/2/votd HTML, redirect.sh
+++ b/data/tests/2/votd HTML, redirect.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/2/votd HTML.sh
+++ b/data/tests/2/votd HTML.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/2/votd JSON, redirect.sh
+++ b/data/tests/2/votd JSON, redirect.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/2/votd JSON.sh
+++ b/data/tests/2/votd JSON.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/2/votd default, redirect.sh
+++ b/data/tests/2/votd default, redirect.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/data/tests/2/votd default.sh
+++ b/data/tests/2/votd default.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/debian/chleb-bible-search-core.postinst
+++ b/debian/chleb-bible-search-core.postinst
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/debian/chleb-bible-search-core.postrm
+++ b/debian/chleb-bible-search-core.postrm
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/debian/chleb-bible-search-core.prerm
+++ b/debian/chleb-bible-search-core.prerm
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,5 +1,5 @@
 Chleb Bible Search
-Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/debian/etc/cron.monthly/chleb-bible-search
+++ b/debian/etc/cron.monthly/chleb-bible-search
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/debian/etc/main.yaml
+++ b/debian/etc/main.yaml
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/debian/etc/votd-mailer.yaml
+++ b/debian/etc/votd-mailer.yaml
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/etc/main.yaml
+++ b/etc/main.yaml
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/etc/test-suite.yaml
+++ b/etc/test-suite.yaml
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/etc/votd-mailer.yaml
+++ b/etc/votd-mailer.yaml
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/info.PL
+++ b/info.PL
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/info/Makefile
+++ b/info/Makefile
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb.pm
+++ b/lib/Chleb.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Args/Base.pm
+++ b/lib/Chleb/Args/Base.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Bible.pm
+++ b/lib/Chleb/Bible.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Bible/Backend.pm
+++ b/lib/Chleb/Bible/Backend.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Bible/Base.pm
+++ b/lib/Chleb/Bible/Base.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Bible/Book.pm
+++ b/lib/Chleb/Bible/Book.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Bible/Chapter.pm
+++ b/lib/Chleb/Bible/Chapter.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Bible/Exclusions.pm
+++ b/lib/Chleb/Bible/Exclusions.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Bible/Search/Query.pm
+++ b/lib/Chleb/Bible/Search/Query.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Bible/Search/Results.pm
+++ b/lib/Chleb/Bible/Search/Results.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Bible/Verse.pm
+++ b/lib/Chleb/Bible/Verse.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Constants.pm
+++ b/lib/Chleb/Constants.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/DI/Config.pm
+++ b/lib/Chleb/DI/Config.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/DI/Container.pm
+++ b/lib/Chleb/DI/Container.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/DI/MockLogger.pm
+++ b/lib/Chleb/DI/MockLogger.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Exception.pm
+++ b/lib/Chleb/Exception.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Server/Dancer2.pm
+++ b/lib/Chleb/Server/Dancer2.pm
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Server/MediaType.pm
+++ b/lib/Chleb/Server/MediaType.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Server/MediaType/Args/ToString.pm
+++ b/lib/Chleb/Server/MediaType/Args/ToString.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Server/MediaType/Item.pm
+++ b/lib/Chleb/Server/MediaType/Item.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Server/Moose.pm
+++ b/lib/Chleb/Server/Moose.pm
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/TemplateProcessor.pm
+++ b/lib/Chleb/TemplateProcessor.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Token.pm
+++ b/lib/Chleb/Token.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Token/Repository.pm
+++ b/lib/Chleb/Token/Repository.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Token/Repository/Base.pm
+++ b/lib/Chleb/Token/Repository/Base.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Token/Repository/DB/Dynamo.pm
+++ b/lib/Chleb/Token/Repository/DB/Dynamo.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Token/Repository/DB/Maria.pm
+++ b/lib/Chleb/Token/Repository/DB/Maria.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Token/Repository/Dummy.pm
+++ b/lib/Chleb/Token/Repository/Dummy.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Token/Repository/Local.pm
+++ b/lib/Chleb/Token/Repository/Local.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Type/Testament.pm
+++ b/lib/Chleb/Type/Testament.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Utils/BooleanParserException.pm
+++ b/lib/Chleb/Utils/BooleanParserException.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Utils/BooleanParserSystemException.pm
+++ b/lib/Chleb/Utils/BooleanParserSystemException.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Utils/BooleanParserUserException.pm
+++ b/lib/Chleb/Utils/BooleanParserUserException.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Utils/OSError/Mapper.pm
+++ b/lib/Chleb/Utils/OSError/Mapper.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/lib/Chleb/Utils/TypeParserException.pm
+++ b/lib/Chleb/Utils/TypeParserException.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Backend_getOrdinalByVerseKey.t
+++ b/t/Backend_getOrdinalByVerseKey.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Backend_getSentimentByOrdinal.t
+++ b/t/Backend_getSentimentByOrdinal.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Bible_getBookByLongName.t
+++ b/t/Bible_getBookByLongName.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Bible_getBookByShortName.t
+++ b/t/Bible_getBookByShortName.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Bible_getVerseByOrdinal.t
+++ b/t/Bible_getVerseByOrdinal.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Book_equals.t
+++ b/t/Book_equals.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Book_getVerseByOrdinal.t
+++ b/t/Book_getVerseByOrdinal.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Chleb_getBible.t
+++ b/t/Chleb_getBible.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Chleb_getTranslation.t
+++ b/t/Chleb_getTranslation.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Chleb_isTestamentMatch.t
+++ b/t/Chleb_isTestamentMatch.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Config_get.t
+++ b/t/Config_get.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Exception.t
+++ b/t/Exception.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Server_MediaType.t
+++ b/t/Server_MediaType.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Server_MediaType_acceptToContentType.t
+++ b/t/Server_MediaType_acceptToContentType.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Server_linkToVerse.t
+++ b/t/Server_linkToVerse.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Server_lookup.t
+++ b/t/Server_lookup.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Server_ping.t
+++ b/t/Server_ping.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Server_random.t
+++ b/t/Server_random.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Server_search.t
+++ b/t/Server_search.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Server_searchResultsToHtml.t
+++ b/t/Server_searchResultsToHtml.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Server_uptime.t
+++ b/t/Server_uptime.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Server_version.t
+++ b/t/Server_version.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Server_versionFilter.t
+++ b/t/Server_versionFilter.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Server_votd.t
+++ b/t/Server_votd.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Token.t
+++ b/t/Token.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/TokenRepository_Local.t
+++ b/t/TokenRepository_Local.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Type_Testament.t
+++ b/t/Type_Testament.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Utils_OSError_Mapper.t
+++ b/t/Utils_OSError_Mapper.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Utils_SecureString.t
+++ b/t/Utils_SecureString.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Utils_boolean.t
+++ b/t/Utils_boolean.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Utils_colorIndexFromWord.t
+++ b/t/Utils_colorIndexFromWord.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Utils_explodeHtmlFilePath.t
+++ b/t/Utils_explodeHtmlFilePath.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Utils_forceArray.t
+++ b/t/Utils_forceArray.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Utils_limitText.t
+++ b/t/Utils_limitText.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Utils_parseIntoType.t
+++ b/t/Utils_parseIntoType.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/Utils_removeArrayEmptyItems.t
+++ b/t/Utils_removeArrayEmptyItems.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/info.t
+++ b/t/info.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/lib/Test/Chleb/DummyType.pm
+++ b/t/lib/Test/Chleb/DummyType.pm
@@ -1,5 +1,5 @@
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/lib/Test/Module/Runnable/Local.pm
+++ b/t/lib/Test/Module/Runnable/Local.pm
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/peace_on_earth.t
+++ b/t/peace_on_earth.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/peace_on_limit.t
+++ b/t/peace_on_limit.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/pride.t
+++ b/t/pride.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/random.t
+++ b/t/random.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/traverse_entire_bible.t
+++ b/t/traverse_entire_bible.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/verse.t
+++ b/t/verse.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/t/votd.t
+++ b/t/votd.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Chleb Bible Search
-# Copyright (c) 2024-2025, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Bump all the references to the date
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

The changeset summary provided is clear and concise. It accurately describes the nature of the changes, which are primarily administrative and do not affect the functionality or logic of the codebase.

However, it's worth noting that manually updating copyright years across multiple files can be error-prone and time-consuming. To improve maintainability and reduce complexity, consider automating this process with a script that updates all copyright notices at once. This script could be run as part of a yearly maintenance task or even integrated into your CI/CD pipeline to ensure copyright notices are always up-to-date.

Here's a simple example of how such a script might look in bash:

```bash
#!/bin/bash

CURRENT_YEAR=$(date +"%Y")
PREVIOUS_YEAR=$((CURRENT_YEAR - 1))

# Find all relevant files (adjust this to suit your needs)
FILES=$(find . -type f \( -name "*.pl" -o -name "*.sh" -o -name "*.pm" \))

for FILE in $FILES
do
    # Replace previous year with current year in each file
    sed -i "s/Copyright $PREVIOUS_YEAR/Copyright $CURRENT_YEAR/g" $FILE
done
```

This script finds all Perl and shell scripts in the project directory and its subdirectories, then replaces the previous year's copyright notice with the current year's notice. You may need to adjust the `find` command to include other file types as necessary.

Remember to test this script thoroughly before using it in a production environment to avoid unintentional modifications.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->