### PR TITLE
💚 all January 2026 fixes to CI / unit tests

### DIFF
--- a/lib/Chleb/Exception.pm
+++ b/lib/Chleb/Exception.pm
@@ -33,7 +33,9 @@ use strict;
 use warnings;
 use Moose;
 
-use HTTP::Status qw(:is);
+use HTTP::Status qw(:is status_message);
+
+use overload q{""} => 'toString', fallback => 1;
 
 has description => (is => 'ro', isa => 'Str');
 
@@ -63,7 +65,8 @@ sub raise {
 
 sub toString {
 	my ($self) = @_;
-	return sprintf('HTTP code %d: %s', $self->statusCode, $self->description);
+	my $description = defined($self->description) ? $self->description : status_message($self->statusCode);
+	return sprintf('HTTP code %d: %s', $self->statusCode, ($self->description // '""'));
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/Chleb/Exception.pm
+++ b/lib/Chleb/Exception.pm
@@ -66,7 +66,7 @@ sub raise {
 sub toString {
 	my ($self) = @_;
 	my $description = defined($self->description) ? $self->description : status_message($self->statusCode);
-	return sprintf('HTTP code %d: %s', $self->statusCode, ($self->description // '""'));
+	return sprintf('HTTP code %d: %s', $self->statusCode, $description);
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/Chleb/Exception.pm
+++ b/lib/Chleb/Exception.pm
@@ -65,7 +65,14 @@ sub raise {
 
 sub toString {
 	my ($self) = @_;
-	my $description = defined($self->description) ? $self->description : status_message($self->statusCode);
+
+	my $description = 'Unknown';
+	if (defined($self->description)) {
+		$description = $self->description;
+	} elsif (my $statusMessage = status_message($self->statusCode)) {
+		$description = $statusMessage;
+	}
+
 	return sprintf('HTTP code %d: %s', $self->statusCode, $description);
 }
 


### PR DESCRIPTION
The time was drifting -- this is a quick workaround.
Additionally, failing tests occasionally printed **Chleb::Exception=HASH** with a memory address as a failure.  Difficult to reproduce, unfortunately, but automagically stringify this, for if/when it happens again.



<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

The changes you've made seem to be well thought out and address several key areas of code quality. Here are some suggestions based on the summaries provided:

1. **MANIFEST, bin/maint/md2html.pl, README.md**: The addition of new HTML files for browsing and updated test scripts is a good move towards improving usability and maintainability. However, ensure that the conversion from uppercase file extensions to lowercase is done in a case-insensitive manner to avoid potential issues with different operating systems.

2. **t/TokenRepository_Local.t**: The introduction of the `__time_ok` helper function is a great way to improve the accuracy and maintainability of your tests. It's always a good idea to abstract complex or repetitive logic into helper functions. Just make sure that this function is thoroughly tested itself, as it's now a critical part of your testing suite.

3. **lib/Chleb/Exception.pm**: Overloading stringification to handle undefined descriptions and using status messages if available is a smart way to prevent potential errors and improve debugging. However, consider adding a default message even if the HTTP status code doesn't provide one, to ensure that there's always some form of description available.

In general, these changes seem to be moving in the right direction. Keep focusing on improving maintainability, robustness, and error handling in your codebase.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->