### PR TITLE
🐛 fix demo test scripts + ARRAY bug!

### DIFF
--- a/bin/demo/john.pl
+++ b/bin/demo/john.pl
@@ -38,7 +38,7 @@ use POSIX qw(EXIT_SUCCESS);
 use Chleb::Bible;
 
 sub main {
-	my $bible = Chleb::Bible->new();
+	my $bible = Chleb::Bible->new({ translation => 'asv' });
 
 	my $query = $bible->newSearchQuery('dwelt')->setLimit(10);
 	# FIXME: Need to limit to one book?  should be able to do this via Query.pm

--- a/debian/rules
+++ b/debian/rules
@@ -41,7 +41,7 @@ override_dh_auto_install:
 	dh_auto_install --destdir=debian/chleb-bible-search-core
 
 override_dh_auto_clean:
-	rm -f log/*.log
+	[ -d log ] && rm -f log/*.log || true
 	dh_auto_clean
 
 .PHONY: override_dh_auto_install

--- a/debian/rules
+++ b/debian/rules
@@ -40,4 +40,8 @@ export DH_VERBOSE=1
 override_dh_auto_install:
 	dh_auto_install --destdir=debian/chleb-bible-search-core
 
+override_dh_auto_clean:
+	rm -f log/*.log
+	dh_auto_clean
+
 .PHONY: override_dh_auto_install

--- a/debian/rules
+++ b/debian/rules
@@ -41,7 +41,7 @@ override_dh_auto_install:
 	dh_auto_install --destdir=debian/chleb-bible-search-core
 
 override_dh_auto_clean:
-	[ -d log ] && rm -f log/*.log || true
+	rm -f log/*.log 2>/dev/null || true
 	dh_auto_clean
 
 .PHONY: override_dh_auto_install override_dh_auto_clean

--- a/debian/rules
+++ b/debian/rules
@@ -44,4 +44,4 @@ override_dh_auto_clean:
 	[ -d log ] && rm -f log/*.log || true
 	dh_auto_clean
 
-.PHONY: override_dh_auto_install
+.PHONY: override_dh_auto_install override_dh_auto_clean

--- a/lib/Chleb/Server/Dancer2.pm
+++ b/lib/Chleb/Server/Dancer2.pm
@@ -396,7 +396,7 @@ get '/1/lookup/:book/:chapter/:verse' => sub {
 		handleException($exception);
 	}
 
-	if (ref($result) ne 'HASH') {
+	if (ref($result) eq '') {
 		my $resultHtml = $result;
 		$result = fetchStaticPage('generic_head', { TITLE => "${PROJECT}: Lookup ${book} ${chapter}:${verse}" });
 		$result .= $resultHtml;

--- a/lib/Chleb/Server/Dancer2.pm
+++ b/lib/Chleb/Server/Dancer2.pm
@@ -404,6 +404,8 @@ get '/1/lookup/:book/:chapter/:verse' => sub {
 
 		$server->dic->logger->trace('1/lookup verse returned as HTML');
 		send_as html => $result;
+	} elsif (ref($result) eq 'ARRAY') {
+		$result = $result->[0];
 	}
 
 	$server->dic->logger->trace('1/lookup verse returned as JSON');


### PR DESCRIPTION




<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

Based on the summary of changes, here are my reviews and suggestions:

1. `bin/demo/john.pl, lib/Chleb/Server/Dancer2.pm`: 

   - Review: The change to include a translation parameter 'asv' when instantiating `Chleb::Bible` is a good practice as it allows for flexibility in handling different translations. Also, updating the logic to handle different types of results (HASH and ARRAY) in the '/1/lookup/:book/:chapter/:verse' route handler improves the robustness of the code.
   
   - Suggestion: Ensure that the new logic correctly handles all possible cases. It would be beneficial to add unit tests to verify this behavior. Also, consider using a more descriptive name than 'asv' for the translation parameter to improve readability.

2. `debian/rules`: 

   - Review: Adding an `override_dh_auto_clean` target to remove log files before cleaning is a good practice as it helps keep the build environment clean. Checking if the `log` directory exists before attempting to remove log files prevents potential errors. Removing the `.PHONY: override_dh_auto_install` line and updating the `.PHONY` target to include both `override_dh_auto_install` and `override_dh_auto_clean` makes the makefile more maintainable.
   
   - Suggestion: Ensure that the removal of log files does not inadvertently delete important information that might be needed for debugging or auditing purposes. Consider archiving the logs instead of deleting them. Also, ensure that the changes to the `.PHONY` target do not affect other parts of the build process.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->