### PR TITLE
🐧 add SysV init wrapper for systemd service

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -255,6 +255,7 @@ debian/source/format
 etc-defaults/main.yaml
 etc-local/main.yaml
 etc/chleb-bible-search.service
+etc/init.d/chleb-bible-search
 etc/log4perl.conf
 etc/logrotate/chleb-bible-search
 etc/main.yaml

--- a/debian/chleb-bible-search-core.install
+++ b/debian/chleb-bible-search-core.install
@@ -1,4 +1,5 @@
 etc/chleb-bible-search.service /usr/lib/systemd/system/
+etc/init.d/chleb-bible-search /etc/init.d/
 etc/nginx/*.example /etc/nginx/sites-available/
 debian/etc/*.conf /etc/chleb-bible-search/
 debian/etc/*.yaml /etc/chleb-bible-search/

--- a/etc/init.d/chleb-bible-search
+++ b/etc/init.d/chleb-bible-search
@@ -1,0 +1,59 @@
+#!/bin/sh
+# Chleb Bible Search
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#     * Neither the name of the Daybo Logic nor the names of its contributors
+#       may be used to endorse or promote products derived from this software
+#       without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+### BEGIN INIT INFO
+# Provides:          chleb-bible-search
+# Required-Start:    $remote_fs $syslog $network
+# Required-Stop:     $remote_fs $syslog $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Chleb Bible Search
+# Description:       Self-hostable microservice for querying and searching the Bible
+### END INIT INFO
+
+. /lib/lsb/init-functions
+
+SERVICE=chleb-bible-search
+
+case "$1" in
+	start|stop|restart|reload|force-reload|status)
+		if [ -d /run/systemd/system ]; then
+			systemctl $1 $SERVICE
+		else
+			log_failure_msg "systemd is required to manage $SERVICE"
+			exit 1
+		fi
+		;;
+	*)
+		echo "Usage: $0 {start|stop|restart|reload|force-reload|status}" >&2
+		exit 1
+		;;
+esac

--- a/etc/init.d/chleb-bible-search
+++ b/etc/init.d/chleb-bible-search
@@ -43,14 +43,14 @@
 
 SERVICE=chleb-bible-search
 
+if ! command -v systemctl > /dev/null; then
+	echo "systemd is required to manage $SERVICE" >&2
+	exit 1
+fi
+
 case "$1" in
 	start|stop|restart|reload|force-reload|status)
-		if command -v systemctl > /dev/null; then
-			systemctl $1 $SERVICE
-		else
-			log_failure_msg "systemd is required to manage $SERVICE"
-			exit 1
-		fi
+		systemctl $1 $SERVICE
 		;;
 	*)
 		echo "Usage: $0 {start|stop|restart|reload|force-reload|status}" >&2

--- a/etc/init.d/chleb-bible-search
+++ b/etc/init.d/chleb-bible-search
@@ -45,7 +45,7 @@ SERVICE=chleb-bible-search
 
 case "$1" in
 	start|stop|restart|reload|force-reload|status)
-		if [ -d /run/systemd/system ]; then
+		if command -v systemctl > /dev/null; then
 			systemctl $1 $SERVICE
 		else
 			log_failure_msg "systemd is required to manage $SERVICE"

--- a/etc/init.d/chleb-bible-search
+++ b/etc/init.d/chleb-bible-search
@@ -50,7 +50,7 @@ fi
 
 case "$1" in
 	start|stop|restart|reload|force-reload|status)
-		systemctl $1 $SERVICE
+		systemctl "$1" "$SERVICE"
 		;;
 	*)
 		echo "Usage: $0 {start|stop|restart|reload|force-reload|status}" >&2

--- a/etc/init.d/chleb-bible-search
+++ b/etc/init.d/chleb-bible-search
@@ -44,7 +44,7 @@
 SERVICE=chleb-bible-search
 
 if ! command -v systemctl > /dev/null; then
-	echo "systemd is required to manage $SERVICE" >&2
+	>&2 echo "Error: systemd is not installed. It is required to manage $SERVICE. Please install systemd and try again."
 	exit 1
 fi
 
@@ -53,7 +53,7 @@ case "$1" in
 		systemctl "$1" "$SERVICE"
 		;;
 	*)
-		echo "Usage: $0 {start|stop|restart|reload|force-reload|status}" >&2
+		>&2 echo "Usage: $0 {start|stop|restart|reload|force-reload|status}"
 		exit 1
 		;;
 esac


### PR DESCRIPTION
Provides /etc/init.d/chleb-bible-search with start|stop|restart| reload|force-reload|status actions, delegating to systemctl. Includes LSB init headers for update-rc.d compatibility.

@coderabbitai: ignore


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

The summary of changes indicates that a new SysV init wrapper for the systemd service `chleb-bible-search` has been added. This is a good practice as it provides compatibility with older systems that still use SysV init scripts, while also allowing newer systems to take advantage of the features provided by systemd.

Here are some points to consider:

1. **Logic:** Ensure that the script correctly delegates start, stop, restart, reload, force-reload, and status actions to `systemctl`. Also, make sure that the script exits with the correct status codes.

2. **Security:** Check if the script is running with appropriate permissions. It should not run with higher privileges than necessary.

3. **Performance:** The performance impact of this change should be minimal since the script simply delegates commands to `systemctl`.

4. **Consistency:** Make sure that the script follows the same conventions as other init scripts in your system.

5. **Error handling:** The script should handle errors gracefully. For example, if `systemctl` is not available on the system, the script should provide a meaningful error message.

6. **Maintainability:** The script should be easy to understand and maintain. Avoid complex logic and clearly document any non-obvious parts.

7. **Modularity:** If there are common operations that are used in other scripts, consider extracting them into a separate script or function.

8. **Complexity:** Keep the script as simple as possible. The main purpose of the script is to delegate commands to `systemctl`, so there's no need for complex logic.

9. **Optimization:** There's likely not much room for optimization in this script. However, ensure that the script doesn't perform unnecessary operations.

10. **Best practices:** Follow best practices for writing shell scripts. For example, use `"$@"` instead of `$*` to preserve word boundaries, and use `$(command)` instead of `` `command` `` for command substitution.

Without the actual code, it's hard to provide more specific feedback. However, these are some general points to consider when writing init scripts.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->