### PR TITLE
🚨 perlcritic (2)

### DIFF
--- a/lib/Chleb/Bible.pm
+++ b/lib/Chleb/Bible.pm
@@ -187,7 +187,7 @@ sub getBookByShortName {
 		die Chleb::Exception->raise(HTTP_NOT_FOUND, $errorMsg);
 	}
 
-	return undef;
+	return;
 }
 
 =item C<getBookByLongName($longName, [$args])>
@@ -226,7 +226,7 @@ sub getBookByLongName {
 		die Chleb::Exception->raise(HTTP_NOT_FOUND, $errorMsg);
 	}
 
-	return undef;
+	return;
 }
 
 =item C<getBookByOrdinal($ordinal, [$args])>
@@ -251,7 +251,7 @@ sub getBookByOrdinal {
 
 	if ($ordinal > $self->bookCount) {
 		if ($args->{nonFatal}) {
-			return undef;
+			return;
 		} else {
 			die Chleb::Exception->raise(HTTP_NOT_FOUND, sprintf('Book ordinal %d out of range, there are %d books in the bible',
 			    $ordinal, $self->bookCount));

--- a/lib/Chleb/Bible/Backend.pm
+++ b/lib/Chleb/Bible/Backend.pm
@@ -159,7 +159,7 @@ sub getOrdinalByVerseKey {
 
 sub getVerseKeyByOrdinal {
 	my ($self, $ordinal) = @_;
-	return undef if (!defined($ordinal));
+	return if (!defined($ordinal));
 	return $self->data->[$MAIN_OFFSET_VERSES]->[$ordinal];
 }
 

--- a/lib/Chleb/Bible/Book.pm
+++ b/lib/Chleb/Bible/Book.pm
@@ -219,7 +219,7 @@ sub getPrev {
 	return $self->bible->getBookByOrdinal($self->ordinal - 1, { nonFatal => 1 })
 	    if ($self->ordinal > 1);
 
-	return undef;
+	return;
 }
 
 =item C<search($query)>
@@ -362,7 +362,7 @@ sub getChapterByOrdinal {
 
 	if ($ordinal > $self->chapterCount) {
 		if ($args->{nonFatal}) {
-			return undef;
+			return;
 		} else {
 			die Chleb::Exception->raise(HTTP_NOT_FOUND, sprintf('Chapter %d not found in %s', $ordinal, $self->toString()));
 		}

--- a/lib/Chleb/Bible/Chapter.pm
+++ b/lib/Chleb/Bible/Chapter.pm
@@ -69,7 +69,7 @@ sub getVerseByOrdinal {
 		});
 	}
 
-	return undef if ($args->{nonFatal});
+	return if ($args->{nonFatal});
 	die Chleb::Exception->raise(HTTP_NOT_FOUND, sprintf('Verse %d not found in %s', $ordinal, $self->toString()));
 }
 
@@ -102,7 +102,7 @@ sub getPrev {
 		return $self->book->getChapterByOrdinal($self->ordinal - 1, { nonFatal => 1 });
 	}
 
-	return undef;
+	return;
 }
 
 sub getPath {

--- a/lib/Chleb/Bible/Verse.pm
+++ b/lib/Chleb/Bible/Verse.pm
@@ -91,7 +91,7 @@ sub getPrev {
 		return $self->chapter->getVerseByOrdinal($self->ordinal - 1, { nonFatal => 1 });
 	}
 
-	return undef;
+	return;
 }
 
 sub equals {

--- a/lib/Chleb/Server/Dancer2.pm
+++ b/lib/Chleb/Server/Dancer2.pm
@@ -171,9 +171,13 @@ sub __detaint {
 
 sub _param {
 	my ($name) = @_;
+
 	my $value = param($name);
-	return unless (defined($value));
-	return __detaint($value, $name);
+	if (defined($value)) {
+		$value = __detaint($value, $name);
+	}
+
+	return $value;
 }
 
 get '/' => sub {

--- a/lib/Chleb/Server/Dancer2.pm
+++ b/lib/Chleb/Server/Dancer2.pm
@@ -172,7 +172,7 @@ sub __detaint {
 sub _param {
 	my ($name) = @_;
 	my $value = param($name);
-	return undef unless (defined($value));
+	return unless (defined($value));
 	return __detaint($value, $name);
 }
 

--- a/lib/Chleb/Server/Dancer2.pm
+++ b/lib/Chleb/Server/Dancer2.pm
@@ -177,6 +177,8 @@ sub _param {
 		$value = __detaint($value, $name);
 	}
 
+	# $value be undef, we never return nothing,
+	# because the Chleb::Utils::forceArray wouldn't work properly.
 	return $value;
 }
 

--- a/lib/Chleb/Token/Repository/Dummy.pm
+++ b/lib/Chleb/Token/Repository/Dummy.pm
@@ -49,7 +49,7 @@ sub create {
 }
 
 sub load {
-	return undef;
+	return;
 }
 
 sub save {

--- a/lib/Chleb/Token/Repository/Local.pm
+++ b/lib/Chleb/Token/Repository/Local.pm
@@ -95,7 +95,7 @@ sub load {
 		my $errNum = $ERRNO;
 		my $errStr = strerror($errNum);
 		if ($evalError =~ m/: $errStr/) {
-			return undef; # not found
+			return; # not found
 		}
 
 		$self->dic->logger->error($evalError);

--- a/lib/Chleb/Token/Repository/Redis.pm
+++ b/lib/Chleb/Token/Repository/Redis.pm
@@ -150,7 +150,7 @@ sub load {
 		$self->dic->logger->error($evalError);
 		die Chleb::Exception->raise(HTTP_INTERNAL_SERVER_ERROR, "error getting session '$value' token via " . __PACKAGE__);
 	} elsif (!$data) {
-		return undef; # not found
+		return; # not found
 	}
 
 	my $token;

--- a/lib/Chleb/Utils/OSError/Mapper.pm
+++ b/lib/Chleb/Utils/OSError/Mapper.pm
@@ -272,6 +272,7 @@ sub __getSymbolicName {
 	my $symbolic = '???';
 
 	foreach my $mnemonic (keys(%!)) {
+		## no critic (TestingAndDebugging::ProhibitNoStrict)
 		no strict 'refs';
 		$mnemonic = "Errno::$mnemonic";
 		$! = &$mnemonic;


### PR DESCRIPTION




<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

Based on the summary of changes, here are my suggestions:

1. `lib/Chleb/Bible.pm, lib/Chleb/Bible/Book.pm, lib/Chleb/Bible/Chapter.pm, lib/Chleb/Bible/Verse.pm, lib/Chleb/Bible/Backend.pm, lib/Chleb/Token/Repository/Dummy.pm, lib/Chleb/Token/Repository/Local.pm, lib/Chleb/Token/Repository/Redis.pm:`

   The change from `return undef;` to `return;` is a good practice in Perl as it makes the code cleaner and more readable. However, ensure that this change does not affect any function that might be expecting an explicit `undef` value.

2. `lib/Chleb/Server/Dancer2.pm:`

   Checking if `$value` is defined before detainting it is a good practice as it prevents potential errors or warnings. This also improves the robustness of your code. However, make sure that the rest of your code can handle situations where `$value` is not defined.

3. `lib/Chleb/Utils/OSError/Mapper.pm:`

   Using `no strict 'refs'` can lead to risky behavior as it turns off some of Perl's safety features. It's generally recommended to avoid using it unless absolutely necessary. If you must use it, limit its scope as much as possible and always turn strictness back on as soon as you're done with the no-strict block. Also, disabling the `ProhibitNoStrict` policy should only be done for testing and debugging, and never in production code.

Remember, these are general suggestions based on the summary provided. For a more detailed review, I would need to see the actual code changes.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->