### PR TITLE
🚨 perlcritic misc fixes for --stern mode

### DIFF
--- a/bin/maint/perlcritic.sh
+++ b/bin/maint/perlcritic.sh
@@ -40,7 +40,13 @@ set -eu
 PERLCRITIC_BIN="${PERLCRITIC_BIN:-perlcritic}"
 
 # Default options (override by setting PERLCRITIC_OPTS in environment if you want)
-DEFAULT_OPTS="--gentle --nocolor --profile-strictness quiet --quiet"
+# levels:
+#  * brutal
+#  * cruel
+#  * harsh
+#  * stern
+#  * gentle
+DEFAULT_OPTS="--stern --nocolor --profile-strictness quiet --quiet"
 
 # If you want to pass extra flags, do:
 #   PERLCRITIC_OPTS="--severity 3" bin/maint/perlcritic.sh lib/Foo.pm

--- a/data/tests/1/lookup HTML, redirect.sh
+++ b/data/tests/1/lookup HTML, redirect.sh
@@ -44,7 +44,7 @@ expectedStatus="307"
 declare -A expectedHeaders=(
 	["Content-Type"]="text/html; charset=utf-8"
 	["Connection"]="keep-alive"
-	["Server"]="Perl Dancer2 0.400001"
+	["Server"]="^Perl Dancer2 [0-9.]+$"
 	["Location"]="/1/lookup/judg/12/6"
 )
 

--- a/lib/Chleb/DI/MockLogger.pm
+++ b/lib/Chleb/DI/MockLogger.pm
@@ -41,7 +41,7 @@ sub BUILD {
 	return;
 }
 
-sub log {
+sub log { ## no critic (Subroutines::ProhibitBuiltinHomonyms)
 	my ($self, $msg) = @_;
 	push(@{ $self->__messages }, $msg);
 	return unless ($ENV{TEST_VERBOSE});
@@ -74,7 +74,7 @@ sub error {
 	return $self->log($msg);
 }
 
-sub warn {
+sub warn { ## no critic (Subroutines::ProhibitBuiltinHomonyms)
 	my ($self, $msg) = @_;
 	return $self->log($msg);
 }

--- a/lib/Chleb/Server/Dancer2.pm
+++ b/lib/Chleb/Server/Dancer2.pm
@@ -96,9 +96,7 @@ sub handleException {
 	}
 
 	$server->dic->logger->error("Internal Server Error: $exception");
-	send_error($exception, 500);
-
-	return;
+	return send_error($exception, 500);
 }
 
 sub fetchStaticPage {
@@ -140,17 +138,19 @@ sub fetchStaticPage {
 	}
 
 	my $error = $ERRNO;
-	send_error("Can't open file '$filePathFailed': $error", $server->dic->errorMapper->map(int($error)));
+	return send_error("Can't open file '$filePathFailed': $error", $server->dic->errorMapper->map(int($error)));
 }
 
 sub serveStaticPage {
 	my ($name, $templateParams) = @_;
 	send_as html => fetchStaticPage($name, $templateParams);
+	return;
 }
 
-sub __configGetPublicDir {
+sub __configSetPublicDir {
 	die('Moose server must be initialized') unless ($server);
-	set public_dir => $server->dic->config->get('Dancer2', 'public_dir', 'data/static/public'),
+	set public_dir => $server->dic->config->get('Dancer2', 'public_dir', 'data/static/public');
+	return;
 }
 
 sub __detaint {
@@ -566,7 +566,7 @@ get '/1/info' => sub {
 sub run {
 	my ($self) = @_;
 	$server = Chleb::Server::Moose->new();
-	__configGetPublicDir();
+	__configSetPublicDir();
 	return $self->dance;
 }
 

--- a/lib/Chleb/Server/Moose.pm
+++ b/lib/Chleb/Server/Moose.pm
@@ -127,9 +127,6 @@ sub title {
 		$self->dic->config->get('server', 'admin_email', 'example@example.org'),
 	));
 
-	# nb. this doesn't work, but perhaps it will be fixed in Plack in the future.
-	$0 = 'chleb-bible-search [server]';
-
 	return;
 }
 
@@ -958,7 +955,7 @@ sub __verseToHtml {
 
 	if ($firstVerseObject->chapter->ordinal < $chapterCount) {
 		my $lastChapter = $chapters[-1];
-		$lastChapterLink = '<a class="vn-link vn-chapter" href="/1/lookup/' . $lastChapter->getPath() . '">last chapter</a>',
+		$lastChapterLink = '<a class="vn-link vn-chapter" href="/1/lookup/' . $lastChapter->getPath() . '">last chapter</a>';
 	}
 
 	my $bookLinkFormat = '<a class="vn-link vn-book" href="/1/lookup/' . $firstVerseObject->book->getPath() . '/1">%s</a>';
@@ -1108,7 +1105,7 @@ sub __searchResultsToHtml {
 }
 
 sub __linkToHome { # add a link to home (root)
-	my $output .= "<p>\r\n";
+	my $output = "<p>\r\n";
 	$output .= sprintf("\t<a class=\"vn-link vn-home\" href=\"%s\">%s</a>\r\n", '/', 'home');
 	$output .= "</p>\r\n";
 	return $output;

--- a/lib/Chleb/Token/Repository.pm
+++ b/lib/Chleb/Token/Repository.pm
@@ -48,12 +48,15 @@ sub repo {
 	    unless (defined($name));
 
 	# TODO: Could we use UNIVERSAL require here?
-	if ($name eq 'Dummy') {
-		return Chleb::Token::Repository::Dummy->new(repo => $self);
-	} elsif ($name eq 'Local') {
-		return Chleb::Token::Repository::Local->new(repo => $self);
-	} elsif ($name eq 'Redis') {
-		return Chleb::Token::Repository::Redis->new(repo => $self);
+	my %repositories = (
+		'Dummy' => 'Chleb::Token::Repository::Dummy',
+		'Local' => 'Chleb::Token::Repository::Local',
+		'Redis' => 'Chleb::Token::Repository::Redis',
+	);
+
+	if (exists $repositories{$name}) {
+		my $class = $repositories{$name};
+		return $class->new(repo => $self);
 	}
 
 	die Chleb::Exception->raise(HTTP_INTERNAL_SERVER_ERROR, "'${name}' is not a known token repository backend");

--- a/lib/Chleb/Token/Repository.pm
+++ b/lib/Chleb/Token/Repository.pm
@@ -44,17 +44,19 @@ use HTTP::Status qw(:constants);
 sub repo {
 	my ($self, $name) = @_;
 
-	if (defined($name)) {
-		if ($name eq 'Dummy') {
-			return Chleb::Token::Repository::Dummy->new(repo => $self);
-		} elsif ($name eq 'Local') {
-			return Chleb::Token::Repository::Local->new(repo => $self);
-		} elsif ($name eq 'Redis') {
-			return Chleb::Token::Repository::Redis->new(repo => $self);
-		}
+	die Chleb::Exception->raise(HTTP_INTERNAL_SERVER_ERROR, 'Backend name must be specified')
+	    unless (defined($name));
+
+	# TODO: Could we use UNIVERSAL require here?
+	if ($name eq 'Dummy') {
+		return Chleb::Token::Repository::Dummy->new(repo => $self);
+	} elsif ($name eq 'Local') {
+		return Chleb::Token::Repository::Local->new(repo => $self);
+	} elsif ($name eq 'Redis') {
+		return Chleb::Token::Repository::Redis->new(repo => $self);
 	}
 
-	...
+	die Chleb::Exception->raise(HTTP_INTERNAL_SERVER_ERROR, "'${name}' is not a known token repository backend");
 }
 
 sub create {

--- a/lib/Chleb/Utils/OSError/Mapper.pm
+++ b/lib/Chleb/Utils/OSError/Mapper.pm
@@ -277,7 +277,7 @@ sub __getSymbolicName {
 		local $OS_ERROR = Errno->can($mnemonic)->();
 		$mnemonic =~ s/^Errno:://;
 		my $value = $OS_ERROR{$mnemonic};
-		if ($value eq $error) {
+		if ($value == $error) {
 			$symbolic = $mnemonic;
 			last;
 		}

--- a/lib/Chleb/Utils/OSError/Mapper.pm
+++ b/lib/Chleb/Utils/OSError/Mapper.pm
@@ -45,6 +45,7 @@ Map system errors to public HTTP errors
 
 extends 'Chleb::Bible::Base';
 
+use English qw(-no_match_vars);
 use Errno;
 use HTTP::Status 6.39 qw(:constants status_constant_name status_message);
 use POSIX qw(strerror);
@@ -271,14 +272,12 @@ sub __getSymbolicName {
 
 	my $symbolic = '???';
 
-	foreach my $mnemonic (keys(%!)) {
-		## no critic (TestingAndDebugging::ProhibitNoStrict)
-		no strict 'refs';
+	foreach my $mnemonic (keys(%OS_ERROR)) {
 		$mnemonic = "Errno::$mnemonic";
-		$! = &$mnemonic;
+		local $OS_ERROR = Errno->can($mnemonic)->();
 		$mnemonic =~ s/^Errno:://;
-		my $value = $!{$mnemonic};
-		if ($value == $error) {
+		my $value = $OS_ERROR{$mnemonic};
+		if ($value eq $error) {
 			$symbolic = $mnemonic;
 			last;
 		}

--- a/lib/Chleb/Utils/OSError/Mapper.pm
+++ b/lib/Chleb/Utils/OSError/Mapper.pm
@@ -212,7 +212,7 @@ locale is not English.
 
 =cut
 
-sub map {
+sub map { ## no critic (Subroutines::ProhibitBuiltinHomonyms)
 	my ($self, $error) = @_;
 	$error //= 0;
 


### PR DESCRIPTION





<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

The changes you've made to the codebase seem to be well thought out and are aimed at improving the overall quality of the code. Here's a brief review of your changes:

1. `bin/maint/perlcritic.sh`: Changing the severity level from `--gentle` to `--stern` in Perl::Critic checks is a good move towards enforcing stricter coding standards, which can help catch more potential issues.

2. `lib/Chleb/DI/MockLogger.pm`: Adding perlcritic exceptions for built-in homonyms in `log` and `warn` functions improves readability and avoids confusion with built-in function names.

3. `lib/Chleb/Server/Dancer2.pm, lib/Chleb/Server/Moose.pm`: The refactoring done here seems to improve the clarity of the code by making it more explicit what each function does and returns. Removing unnecessary assignments and correcting syntax errors also contributes to cleaner, more maintainable code.

4. `lib/Chleb/Token/Repository.pm`: The addition of error handling in the `repo` function is a significant improvement. It ensures that the backend name is specified before proceeding with repository creation, preventing potential runtime errors. Using a hash lookup for repository classes based on the provided name is a good practice as it simplifies the code and makes it more efficient.

5. `lib/Chleb/Utils/OSError/Mapper.pm`: Replacing `%!` with `%OS_ERROR` and modifying the way symbolic names are retrieved from errors enhances the accuracy of error handling. Using the English module for better readability is a good practice.

6. `data/tests/1/lookup HTML, redirect.sh`: Updating the expected server header value to match a regex pattern in the test script increases the flexibility of the test and allows it to handle a wider range of valid responses.

Overall, these changes enhance the code's readability, maintainability, and error handling. Good job!
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->