### PR TITLE
🔨 support checkout development

### DIFF
--- a/bin/core/run.sh
+++ b/bin/core/run.sh
@@ -38,6 +38,17 @@ APP='/usr/share/chleb-bible-search/app.psgi'
 SOCKET='/var/run/chleb-bible-search/sock'
 PLACK='/usr/bin/plackup'
 
+if [ -e "$(pwd)/.git" ] && [ -f 'bin/core/app.psgi' ]; then
+	$PLACK \
+		-I lib \
+		--no-default-middleware \
+		-r \
+		-R lib,data/static,etc,bin/core \
+		-p 5000 \
+		-a bin/core/app.psgi
+	exit $?
+fi
+
 nProc=$DEFAULT_NPROC
 if [ -f "$CONFIG_PATH" ]; then
 	json=$($YAML_SCRIPT < $CONFIG_PATH)

--- a/etc/nginx/chleb-bible-search.example
+++ b/etc/nginx/chleb-bible-search.example
@@ -15,6 +15,20 @@ server {
 		proxy_ssl_server_name off;
 	}
 
+	# if you are running a local checkout, use this instead!
+#	location / {
+#		if ($request_method = OPTIONS) {
+#			return 204;
+#		}
+#
+#		proxy_set_header Host $host;
+#		proxy_set_header X-Real-IP $remote_addr;
+#		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#		proxy_set_header X-Forwarded-Proto $scheme;
+#
+#		proxy_pass http://127.0.0.1:5000;
+#	}
+
     listen 443 ssl; # managed by Certbot
     ssl_certificate /etc/letsencrypt/live/chleb-api.example.org/fullchain.pem; # managed by Certbot
     ssl_certificate_key /etc/letsencrypt/live/chleb-api.example.org/privkey.pem; # managed by Certbot


### PR DESCRIPTION
Support developing from the local checkout.
This is for a faster turn-around, because I need to do a lot of visual stuff a lot quicker.