### PR TITLE
👷 functional tests require artificial delay because of session cookies

### DIFF
--- a/bin/maint/run-functional-tests.sh
+++ b/bin/maint/run-functional-tests.sh
@@ -48,7 +48,8 @@ if [[ ! -d "$BASE_DIR" ]]; then
 fi
 
 # Check if httpie (http command) is installed
-if command -v http >/dev/null 2>&1; then
+REAL_HTTP=$(command -v http || true)
+if [[ -n "$REAL_HTTP" ]]; then
 	echo "✅ HTTPie detected"
 else
 	echo "⚠️ HTTPie is not installed or not in the PATH" >&2
@@ -61,6 +62,19 @@ else
 	echo "⚠️ Host $SERVER_HOST does not resolve."
 	exit 0
 fi
+
+httpWrapperDir=$(mktemp -d)
+trap 'rm -rf "$httpWrapperDir"' EXIT
+
+cat > "$httpWrapperDir/http" <<'EOS'
+#!/usr/bin/env bash
+sleep "${CHLEB_HTTP_TEST_DELAY:-1}"
+exec "$CHLEB_REAL_HTTP" "$@"
+EOS
+chmod +x "$httpWrapperDir/http"
+
+export CHLEB_REAL_HTTP="$REAL_HTTP"
+export PATH="$httpWrapperDir:$PATH"
 
 # Find and execute .sh files
 while IFS= read -r -d '' script; do

--- a/data/tests/1/lookup HTML, redirect.sh
+++ b/data/tests/1/lookup HTML, redirect.sh
@@ -44,7 +44,6 @@ expectedStatus="307"
 declare -A expectedHeaders=(
 	["Content-Type"]="text/html; charset=utf-8"
 	["Connection"]="keep-alive"
-	["Server"]="^Perl Dancer2 [0-9.]+$"
 	["Location"]="/1/lookup/judg/12/6"
 )
 


### PR DESCRIPTION
Now that sessions are enabled by default, we need to artificially delay tests to ensure we don't run into dampening.
Additionally, the Server isn't always Dancer2, it could be the web server.  Remove this test.