### PR TITLE
🐛 prefer source data over installed data

### DIFF
--- a/lib/Chleb/Bible/Backend.pm
+++ b/lib/Chleb/Bible/Backend.pm
@@ -1062,6 +1062,9 @@ sub __makeDataDir {
 	my ($self) = @_;
 
 	Readonly my @PATHS => ('data', '/usr/share/chleb-bible-search');
+	# In a source checkout, do not fall through to stale installed data just because generated SQLite is absent.
+	return $PATHS[0] if (-d $PATHS[0] && -d join('/', $PATHS[0], 'static'));
+
 	foreach my $path (@PATHS) {
 		if (-d $path) {
 			my @sourceFiles = $self->__sourceFilesInPath($path);

--- a/t/Backend_sourceSelection.t
+++ b/t/Backend_sourceSelection.t
@@ -100,6 +100,20 @@ sub testFallbackToCoreWhenNoSingleFile {
 	return EXIT_SUCCESS;
 }
 
+sub testLocalDataDirWinsWithoutGeneratedSqlite {
+	my ($self) = @_;
+
+	my $root = tempdir(CLEANUP => 1);
+	mkdir($root . '/data') or die("mkdir $root/data failed: $!");
+	mkdir($root . '/data/static') or die("mkdir $root/data/static failed: $!");
+
+	chdir($root) or die("chdir $root failed: $!");
+	my $backend = bless({}, 'Chleb::Bible::Backend');
+	is($backend->__makeDataDir(), 'data', 'source checkout data dir wins even before generated SQLite exists');
+
+	return EXIT_SUCCESS;
+}
+
 sub __makeSourceFile {
 	my ($self, $dir, $fileName, $translations) = @_;
 


### PR DESCRIPTION
Avoid falling through to stale installed SQLite sources when running from a source checkout whose generated data artifacts have not been built yet.