### PR TITLE
🔒 Logged JWT hashes were identical

### DIFF
--- a/lib/Chleb/Server/Dampen.pm
+++ b/lib/Chleb/Server/Dampen.pm
@@ -129,10 +129,10 @@ sub dampen {
 	return 0;
 }
 
-=item C<dampenSession($tokenValue, $isJWT)>
+=item C<dampenSession($sessionToken)>
 
-Enforces a sliding window rate limit for authenticated clients.  C<$tokenValue> is
-the raw session token string.
+Enforces a sliding window rate limit for authenticated clients.  C<$sessionToken>
+is the L<Chleb::Token> being rate limited.
 
 The window size and maximum request count are read from the server configuration
 (C<rate_limit.session_window_seconds>, default 60; C<rate_limit.session_max_requests>,
@@ -143,7 +143,9 @@ Returns C<1> if the request should be denied, C<0> otherwise.
 =cut
 
 sub dampenSession {
-	my ($self, $tokenValue, $isJWT) = @_;
+	my ($self, $sessionToken) = @_;
+	my $tokenValue = $sessionToken->value;
+	my $isJWT = $sessionToken->source->isa('Chleb::Token::Repository::JWT');
 
 	my $windowSecs  = $self->dic->config->get('rate_limit', 'session_window_seconds', 60);
 	my $maxRequests = $self->dic->config->get('rate_limit', 'session_max_requests',   100);

--- a/lib/Chleb/Server/Dampen.pm
+++ b/lib/Chleb/Server/Dampen.pm
@@ -36,6 +36,7 @@ use Moose;
 
 extends 'Chleb::Bible::Base';
 
+use Chleb::Token;
 use Chleb::Server::Dampen::Store::Memcached;
 use Chleb::Server::Dampen::Store::Memory;
 
@@ -128,7 +129,7 @@ sub dampen {
 	return 0;
 }
 
-=item C<dampenSession($tokenValue)>
+=item C<dampenSession($tokenValue, $isJWT)>
 
 Enforces a sliding window rate limit for authenticated clients.  C<$tokenValue> is
 the raw session token string.
@@ -142,7 +143,7 @@ Returns C<1> if the request should be denied, C<0> otherwise.
 =cut
 
 sub dampenSession {
-	my ($self, $tokenValue) = @_;
+	my ($self, $tokenValue, $isJWT) = @_;
 
 	my $windowSecs  = $self->dic->config->get('rate_limit', 'session_window_seconds', 60);
 	my $maxRequests = $self->dic->config->get('rate_limit', 'session_max_requests',   100);
@@ -151,7 +152,7 @@ sub dampenSession {
 	if ($self->__checkStore('dampenSession', $tokenValue, $currentTime, $windowSecs, $maxRequests)) {
 		$self->dic->logger->warn(sprintf(
 			'Session %s exceeded %d requests in %ds window, denying',
-			substr($tokenValue, 0, 8), $maxRequests, $windowSecs,
+			Chleb::Token->logValue($tokenValue, $isJWT), $maxRequests, $windowSecs,
 		));
 		return 1;
 	}

--- a/lib/Chleb/Server/Moose.pm
+++ b/lib/Chleb/Server/Moose.pm
@@ -2241,7 +2241,10 @@ sub handleSessionToken {
 		));
 	}
 
-	if ($self->__damper->dampenSession($sessionToken->value)) {
+	if ($self->__damper->dampenSession(
+		$sessionToken->value,
+		$sessionToken->source->isa('Chleb::Token::Repository::JWT'),
+	)) {
 		my $retryAfterSeconds = $self->dic->config->get('rate_limit', 'session_window_seconds', 60);
 		Chleb::Server::Dancer2::handleException(Chleb::Exception->raise(
 			HTTP_TOO_MANY_REQUESTS,

--- a/lib/Chleb/Server/Moose.pm
+++ b/lib/Chleb/Server/Moose.pm
@@ -2241,10 +2241,7 @@ sub handleSessionToken {
 		));
 	}
 
-	if ($self->__damper->dampenSession(
-		$sessionToken->value,
-		$sessionToken->source->isa('Chleb::Token::Repository::JWT'),
-	)) {
+	if ($self->__damper->dampenSession($sessionToken)) {
 		my $retryAfterSeconds = $self->dic->config->get('rate_limit', 'session_window_seconds', 60);
 		Chleb::Server::Dancer2::handleException(Chleb::Exception->raise(
 			HTTP_TOO_MANY_REQUESTS,

--- a/lib/Chleb/Token.pm
+++ b/lib/Chleb/Token.pm
@@ -106,11 +106,7 @@ retain their existing first 12 characters.
 
 sub logValue {
 	my ($class, $value, $isJWT) = @_;
-
-	if ($isJWT) {
-		return substr(Digest::SHA::sha256_hex($value), 0, 12);
-	}
-
+	return substr(Digest::SHA::sha256_hex($value), 0, 12) if ($isJWT);
 	return substr($value, 0, 12);
 }
 

--- a/lib/Chleb/Token.pm
+++ b/lib/Chleb/Token.pm
@@ -90,6 +90,30 @@ has dirty => (is => 'rw', isa => 'Bool', default => 0);
 
 has isNew => (is => 'rw', isa => 'Bool', default => 1);
 
+=head1 METHODS
+
+=over
+
+=item C<logValue($value, $isJWT)>
+
+Returns a short value suitable for logging. JWT values are represented by the
+first 12 hexadecimal characters from their SHA-256 digest; other token values
+retain their existing first 12 characters.
+
+=back
+
+=cut
+
+sub logValue {
+	my ($class, $value, $isJWT) = @_;
+
+	if ($isJWT) {
+		return substr(Digest::SHA::sha256_hex($value), 0, 12);
+	}
+
+	return substr($value, 0, 12);
+}
+
 sub __markDirty {
 	my ($self) = @_;
 	$self->dirty(1);
@@ -108,7 +132,7 @@ sub _generate { ## no critic (Subroutines::ProhibitUnusedPrivateSubroutines)
 # Invoked by Moose as the lazy builder for the shortValue attribute.
 sub _makeShortValue { ## no critic (Subroutines::ProhibitUnusedPrivateSubroutines)
 	my ($self) = @_;
-	return substr($self->value, 0, 12);
+	return $self->logValue($self->value, $self->source->isa('Chleb::Token::Repository::JWT'));
 }
 
 sub save {

--- a/lib/Chleb/Token.pm
+++ b/lib/Chleb/Token.pm
@@ -42,6 +42,7 @@ use Readonly;
 
 Readonly our $DEFAULT_TTL => 604_800; # one week
 Readonly our $DATA_VERSION_MAJOR => 3;
+Readonly our $LENGTH_SHORT => 12;
 
 has ttl => (is => 'ro', isa => 'Int', required => 1, default => $DEFAULT_TTL);
 
@@ -97,8 +98,8 @@ has isNew => (is => 'rw', isa => 'Bool', default => 1);
 =item C<logValue($value, $isJWT)>
 
 Returns a short value suitable for logging. JWT values are represented by the
-first 12 hexadecimal characters from their SHA-256 digest; other token values
-retain their existing first 12 characters.
+first C<$LENGTH_SHORT> hexadecimal characters from their SHA-256 digest; other
+token values retain their existing first C<$LENGTH_SHORT> characters.
 
 =back
 
@@ -106,8 +107,8 @@ retain their existing first 12 characters.
 
 sub logValue {
 	my ($class, $value, $isJWT) = @_;
-	return substr(Digest::SHA::sha256_hex($value), 0, 12) if ($isJWT);
-	return substr($value, 0, 12);
+	return substr(Digest::SHA::sha256_hex($value), 0, $LENGTH_SHORT) if ($isJWT);
+	return substr($value, 0, $LENGTH_SHORT);
 }
 
 sub __markDirty {

--- a/t/Server_dampen.t
+++ b/t/Server_dampen.t
@@ -48,6 +48,8 @@ use POSIX qw(EXIT_FAILURE EXIT_SUCCESS);
 use Chleb::DI::Container;
 use Chleb::DI::MockLogger;
 use Chleb::Server::Dampen;
+use Chleb::Token;
+use Chleb::Token::Repository;
 use Digest::SHA qw(sha256_hex);
 use File::Temp qw(tempdir);
 use Test::More 0.96;
@@ -94,7 +96,7 @@ sub testIpDampenDeniesSameSecond {
 sub testSessionWindowAllows {
 	my ($self) = @_;
 
-	my $token = 'token-allow-test';
+	my $token = $self->__makeToken('token-allow-test');
 	my $allowed = 1;
 	for (my $requestI = 1; $requestI <= 100; $requestI++) {
 		$allowed &&= ($self->sut->dampenSession($token) == 0);
@@ -107,13 +109,13 @@ sub testSessionWindowAllows {
 sub testSessionWindowDenies {
 	my ($self) = @_;
 
-	my $token = 'eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjF9.signature';
+	my $token = $self->__makeToken('eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjF9.signature', 1);
 	for (1..100) {
-		$self->sut->dampenSession($token, 1);
+		$self->sut->dampenSession($token);
 	}
-	is($self->sut->dampenSession($token, 1), 1, 'request over limit is denied');
+	is($self->sut->dampenSession($token), 1, 'request over limit is denied');
 	$self->sut->dic->logger->isLogged(
-		qr/Session @{[substr(sha256_hex($token), 0, 12)]} exceeded 100 requests in 60s window, denying/,
+		qr/Session @{[substr(sha256_hex($token->value), 0, 12)]} exceeded 100 requests in 60s window, denying/,
 	);
 
 	return EXIT_SUCCESS;
@@ -122,7 +124,7 @@ sub testSessionWindowDenies {
 sub testSessionWindowExpiry {
 	my ($self) = @_;
 
-	my $token = 'token-expiry-test';
+	my $token = $self->__makeToken('token-expiry-test');
 	for (1..100) {
 		$self->sut->dampenSession($token);
 	}
@@ -130,6 +132,17 @@ sub testSessionWindowExpiry {
 	is($self->sut->dampenSession($token), 0, 'expired timestamps are pruned and request is allowed');
 
 	return EXIT_SUCCESS;
+}
+
+sub __makeToken {
+	my ($self, $value, $isJWT) = @_;
+	my $repo = Chleb::Token::Repository->new({ dic => $self->sut->dic });
+	my $source = $repo->repo($isJWT ? 'JWT' : 'Local');
+	return Chleb::Token->new({
+		_repo => $repo,
+		_source => $source,
+		_value => $value,
+	});
 }
 
 sub testChurnAllows {

--- a/t/Server_dampen.t
+++ b/t/Server_dampen.t
@@ -48,6 +48,7 @@ use POSIX qw(EXIT_FAILURE EXIT_SUCCESS);
 use Chleb::DI::Container;
 use Chleb::DI::MockLogger;
 use Chleb::Server::Dampen;
+use Digest::SHA qw(sha256_hex);
 use File::Temp qw(tempdir);
 use Test::More 0.96;
 
@@ -106,11 +107,14 @@ sub testSessionWindowAllows {
 sub testSessionWindowDenies {
 	my ($self) = @_;
 
-	my $token = 'token-deny-test';
+	my $token = 'eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjF9.signature';
 	for (1..100) {
-		$self->sut->dampenSession($token);
+		$self->sut->dampenSession($token, 1);
 	}
-	is($self->sut->dampenSession($token), 1, 'request over limit is denied');
+	is($self->sut->dampenSession($token, 1), 1, 'request over limit is denied');
+	$self->sut->dic->logger->isLogged(
+		qr/Session @{[substr(sha256_hex($token), 0, 12)]} exceeded 100 requests in 60s window, denying/,
+	);
 
 	return EXIT_SUCCESS;
 }

--- a/t/Server_dampen.t
+++ b/t/Server_dampen.t
@@ -115,7 +115,7 @@ sub testSessionWindowDenies {
 	}
 	is($self->sut->dampenSession($token), 1, 'request over limit is denied');
 	$self->sut->dic->logger->isLogged(
-		qr/Session @{[substr(sha256_hex($token->value), 0, 12)]} exceeded 100 requests in 60s window, denying/,
+		qr/Session @{[substr(sha256_hex($token->value), 0, $Chleb::Token::LENGTH_SHORT)]} exceeded 100 requests in 60s window, denying/,
 	);
 
 	return EXIT_SUCCESS;

--- a/t/Token.t
+++ b/t/Token.t
@@ -48,6 +48,7 @@ use Chleb::DI::MockLogger;
 use Chleb::Token;
 use Chleb::Token::Repository;
 use Chleb::Token::Repository::Dummy;
+use Digest::SHA qw(sha256_hex);
 use Test::Deep qw(cmp_deeply all isa methods bool re shallow);
 use Test::Exception;
 use Test::More 0.96;
@@ -97,6 +98,17 @@ sub testInitWithValue {
 	$self->__readOnlyValueCheck($self->uniqueStr());
 
 	is($self->sut->value, $value, 'value is still set correctly');
+
+	return EXIT_SUCCESS;
+}
+
+sub testLogValue {
+	plan tests => 3;
+
+	my $jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjF9.signature';
+	is(Chleb::Token->logValue($jwt, 1), substr(sha256_hex($jwt), 0, 12), 'JWT log value is a truncated SHA-256 digest');
+	is(Chleb::Token->logValue('token-plain'), 'token-plain', 'non-JWT log value is unchanged');
+	is(Chleb::Token->logValue('one.two.three'), 'one.two.thre', 'non-JWT dotted value is unchanged');
 
 	return EXIT_SUCCESS;
 }

--- a/t/Token.t
+++ b/t/Token.t
@@ -106,9 +106,9 @@ sub testLogValue {
 	plan tests => 3;
 
 	my $jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjF9.signature';
-	is(Chleb::Token->logValue($jwt, 1), substr(sha256_hex($jwt), 0, 12), 'JWT log value is a truncated SHA-256 digest');
+	is(Chleb::Token->logValue($jwt, 1), substr(sha256_hex($jwt), 0, $Chleb::Token::LENGTH_SHORT), 'JWT log value is a truncated SHA-256 digest');
 	is(Chleb::Token->logValue('token-plain'), 'token-plain', 'non-JWT log value is unchanged');
-	is(Chleb::Token->logValue('one.two.three'), 'one.two.thre', 'non-JWT dotted value is unchanged');
+	is(Chleb::Token->logValue('one.two.three'), substr('one.two.three', 0, $Chleb::Token::LENGTH_SHORT), 'non-JWT dotted value is unchanged');
 
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Not useful for the administrator.  Ensure that logging the tokens is also always 12 characters only.