### PR TITLE
🔨 pass filenames to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,17 +5,20 @@ repos:
         name: Block line-number/markdown corruption in lib/
         entry: bin/git/hooks/run-trap-goose.sh
         language: system
-        pass_filenames: false
+        pass_filenames: true
+        files: ^lib/
       - id: text-final-newline
         name: text files end with newline
         entry: bin/git/hooks/run-text-final-newline.sh
         language: system
+        pass_filenames: true
         types: [text]
       - id: run-perlcritic
         name: perlcritic
         entry: bin/git/hooks/run-perlcritic.sh
         language: system
-        pass_filenames: false
+        pass_filenames: true
+        files: (?i)\.p[lm]$
       - id: run-perlc
         name: perl compile check
         entry: bin/git/hooks/run-perlc.sh
@@ -26,10 +29,11 @@ repos:
         name: PoD check
         entry: bin/git/hooks/run-podchecker.sh
         language: system
-        pass_filenames: false
+        pass_filenames: true
+        files: (?i)\.p[lm]$
       - id: openapi-check
         name: OpenAPI Check
         entry: bin/maint/swagger-check.sh
         language: system
-        pass_filenames: false
+        pass_filenames: true
         files: ^swagger\.yaml$

--- a/bin/git/hooks/run-perlcritic.sh
+++ b/bin/git/hooks/run-perlcritic.sh
@@ -29,7 +29,9 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-scriptDir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-repoRoot=$(CDPATH= cd -- "$scriptDir/../../.." && pwd)
+if [ "$#" -eq 0 ]; then
+	exit 0
+fi
 
-find "${repoRoot}/lib/" -name "*.pm" -type f -exec "${scriptDir}/../../maint/perlcritic.sh" {} +
+scriptDir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+"${scriptDir}/../../maint/perlcritic.sh" "$@"

--- a/bin/git/hooks/run-podchecker.sh
+++ b/bin/git/hooks/run-podchecker.sh
@@ -31,9 +31,11 @@
 
 set -euo pipefail
 
-scriptDir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-repoRoot=$(CDPATH= cd -- "$scriptDir/../../.." && pwd)
+if [ "$#" -eq 0 ]; then
+	exit 0
+fi
 
-while IFS= read -r -d '' f; do
-	"${scriptDir}/../../maint/podchecker.sh" "$f"
-done < <(find "$repoRoot/lib" -name '*.pm' -type f -print0)
+scriptDir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+for file in "$@"; do
+	"${scriptDir}/../../maint/podchecker.sh" "$file"
+done

--- a/bin/git/hooks/run-trap-goose.sh
+++ b/bin/git/hooks/run-trap-goose.sh
@@ -29,23 +29,23 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-scriptDir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-repoRoot=$(CDPATH= cd -- "$scriptDir/../../.." && pwd)
-
-dir="${repoRoot}/lib/"
-
-if [ ! -d "$dir" ]; then
-	>&2 echo "Error: Directory $dir does not exist or is inaccessible."
-	exit 1
+if [ "$#" -eq 0 ]; then
+	exit 0
 fi
 
-# Reject common corruption patterns in lib/
-# - markdown fences
-# - file headers like "### /path/file"
-# - line-number prefixes like "123: "
-if grep -R -n -E '^(###\s+/|```|[0-9]+:\s)' "$dir" >/dev/null 2>&1; then
-	echo "Error: Detected Goose-style corruption in lib/ (headers, fences, or line numbers)."
-	exit 1
-fi
+for file in "$@"; do
+	case "$file" in
+		lib/*)
+			# Reject common corruption patterns in lib/:
+			# - markdown fences
+			# - file headers like "### /path/file"
+			# - line-number prefixes like "123: "
+			if grep -n -E '^(###\s+/|```|[0-9]+:\s)' "$file" >/dev/null 2>&1; then
+				echo "Error: Detected Goose-style corruption in $file (headers, fences, or line numbers)."
+				exit 1
+			fi
+			;;
+	esac
+done
 
 exit 0

--- a/bin/maint/swagger-check.sh
+++ b/bin/maint/swagger-check.sh
@@ -29,4 +29,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-npx @redocly/cli lint --extends=recommended swagger.yaml
+if [ "$#" -eq 0 ]; then
+	set -- swagger.yaml
+fi
+
+npx @redocly/cli lint --extends=recommended "$@"


### PR DESCRIPTION
This is an optimization, so we don't check files we are not committing from within the Git hooks