### PR TITLE
🔨 calculate server child count

### DIFF
--- a/bin/core/calculate-children.sh
+++ b/bin/core/calculate-children.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Chleb Bible Search
 # Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
 # All rights reserved.
@@ -12,14 +13,10 @@
 #       notice, this list of conditions and the following disclaimer in the
 #       documentation and/or other materials provided with the distribution.
 #
-#     * Neither the name of the Daybo Logic nor the names of its contributors
-#       may be used to endorse or promote products derived from this software
-#       without specific prior written permission.
-#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
 # LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
 # CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
 # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
@@ -28,33 +25,37 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-server:
-  uptime_file: cache/startup.txt
-  children: 'auto'
-  max_children: 30
-votd_exclude:
-  terms:
-    - fornication
-    - circumcision
-    - circumcised
-    - harlots
-  refs:
-    - Lev 20:13
-    - Gen 19:8
-    - Psa 137:9
-    - Judges 19:22-29
-    - Kefir 50:1
-    - Rev 1000:11
-    - Deu 22:21
-rate_limit:
-  backend: memcached
-  backend_memcached:
-    servers:
-      - 127.0.0.1:11211
-    prefix: chleb:dampen
-  session_window_seconds: 60    # rolling window size for session token holders
-  session_max_requests: 100     # max requests within that window
-  session_churn_window_seconds: 300  # lookback window for token-churn detection
-  session_churn_limit: 10       # distinct tokens from one IP before denying
-Dancer2:
-  public_dir: data/static/public
+set -euo pipefail
+
+# These values are mebibytes (MiB), not decimal megabytes (MB).
+CHILD_MEMORY_MIB=512
+MEMORY_RESERVE_MIB=256
+
+if [[ ! -r /proc/meminfo ]]; then
+	echo 'ERROR: Cannot read /proc/meminfo' >&2
+	exit 1
+fi
+
+read -r ram_kib swap_kib < <(
+	awk '
+		$1 == "MemTotal:"  { ram = $2 }
+		$1 == "SwapTotal:" { swap = $2 }
+		END {
+			if (ram == "" || swap == "") {
+				exit 1
+			}
+			print ram, swap
+		}
+	' /proc/meminfo
+)
+
+ram_mib=$((ram_kib / 1024))
+swap_mib=$((swap_kib / 1024))
+usable_mib=$((ram_mib + swap_mib - MEMORY_RESERVE_MIB))
+
+children=$((usable_mib / CHILD_MEMORY_MIB))
+if (( children < 1 )); then
+	children=1
+fi
+
+printf '%d\n' "$children"

--- a/bin/core/run.sh
+++ b/bin/core/run.sh
@@ -32,6 +32,7 @@
 set -eu
 
 DEFAULT_NPROC=10
+DEFAULT_MAX_NPROC=30
 YAML_SCRIPT='/usr/share/chleb-bible-search/yaml2json.pl'
 CONFIG_DIR='/etc/chleb-bible-search'
 APP='/usr/share/chleb-bible-search/app.psgi'
@@ -54,6 +55,7 @@ if [ -e "$(pwd)/.git" ] && [ -f 'bin/core/app.psgi' ]; then
 fi
 
 nProc=$DEFAULT_NPROC
+maxChildren=$DEFAULT_MAX_NPROC
 if [ -f "$CONFIG_DIR/main.yaml" ]; then
 	json=$($YAML_SCRIPT \
 		"$CONFIG_DIR/main.yaml" \
@@ -63,6 +65,25 @@ if [ -f "$CONFIG_DIR/main.yaml" ]; then
 	__nProc=$(echo $json | jq -r .server.children)
 	if [ "$__nProc" != 'null' ]; then
 		nProc=$__nProc
+	fi
+	__maxChildren=$(echo $json | jq -r .server.max_children)
+	if [ "$__maxChildren" != 'null' ]; then
+		maxChildren=$__maxChildren
+	fi
+fi
+
+if [ "$nProc" = 'auto' ]; then
+	calculateChildren='/usr/share/chleb-bible-search/calculate-children.sh'
+	if [ ! -x "$calculateChildren" ]; then
+		calculateChildren=$(dirname "$0")/calculate-children.sh
+	fi
+	if [ ! -x "$calculateChildren" ]; then
+		echo 'ERROR: Cannot calculate automatic child count' >&2
+		exit 1
+	fi
+	nProc=$($calculateChildren)
+	if [ "$maxChildren" != 'null' ] && [ "$nProc" -gt "$maxChildren" ]; then
+		nProc=$maxChildren
 	fi
 fi
 

--- a/debian/etc/main.yaml
+++ b/debian/etc/main.yaml
@@ -29,7 +29,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 server:
-  children: 30
+  children: 'auto'
+  max_children: 30
   uptime_file: /var/run/chleb-bible-search/startup.txt
 votd_exclude:
   terms:

--- a/etc/main.yaml
+++ b/etc/main.yaml
@@ -30,8 +30,7 @@
 
 server:
   uptime_file: cache/startup.txt
-  children: 'auto'
-  max_children: 30
+#  children: 30
 votd_exclude:
   terms:
     - fornication


### PR DESCRIPTION
Dynamically decide how many children should run on the server at startup.  Very useful for us, as the project isn't receiving much traffic at the moment, and runs on only one, low-powered shared jail.