### PR TITLE
🩹 keep SQLite temp files out of /tmp

### DIFF
--- a/lib/Chleb/Bible/Backend.pm
+++ b/lib/Chleb/Bible/Backend.pm
@@ -1100,7 +1100,11 @@ the best available source file without relying on filenames alone.
 
 sub __inspectSourceFile {
 	my ($self, $sourceFile) = @_;
-	my ($tempHandle, $tempPath) = tempfile(SUFFIX => '.sqlite', UNLINK => 1);
+	my ($tempHandle, $tempPath) = tempfile(
+		DIR    => $self->__makeTempDir(),
+		SUFFIX => '.sqlite',
+		UNLINK => 1,
+	);
 	close($tempHandle);
 	gunzip $sourceFile => $tempPath
 	   or die("gunzip \"" . $sourceFile . "\" failed: $GunzipError\n");
@@ -1168,6 +1172,26 @@ sub __makeCacheDir {
 	croak('No cache dir available');
 }
 
+=item C<__makeTempDir()>
+
+Return a writable directory for temporary SQLite work.  Prefer the selected
+backend cache directory and use C</var/tmp> when that directory is not
+writable.  Large compressed Bible databases must not be expanded in the
+usually much smaller system temporary filesystem.
+
+=cut
+
+sub __makeTempDir {
+	my ($self) = @_;
+
+	Readonly my @PATHS => ($self->cacheDir, '/var/tmp');
+	foreach my $path (@PATHS) {
+		return $path if (-d $path && -w $path);
+	}
+
+	croak('No writable temporary directory available');
+}
+
 =item C<__makeCachePath()>
 
 Return the decompressed SQLite cache path, refreshing it when the compressed
@@ -1206,8 +1230,21 @@ sub __makeCachePath {
 	}
 
 	if ($needsRefresh) {
-		gunzip $self->compressedPath => $path
-		   or die("gunzip \"" . $self->compressedPath . "\" failed: $GunzipError\n");
+		my ($tempHandle, $tempPath) = tempfile(
+			DIR    => $self->cacheDir,
+			SUFFIX => '.sqlite',
+			UNLINK => 0,
+		);
+		close($tempHandle) or croak("close($tempPath) failed: $ERRNO");
+		if (!gunzip($self->compressedPath => $tempPath)) {
+			unlink($tempPath);
+			die("gunzip \"" . $self->compressedPath . "\" failed: $GunzipError\n");
+		}
+		rename($tempPath, $path) or do {
+			my $renameError = $ERRNO;
+			unlink($tempPath);
+			croak("rename($tempPath -> $path) failed: $renameError");
+		};
 	}
 
 	return $path;

--- a/t/Backend_sourceSelection.t
+++ b/t/Backend_sourceSelection.t
@@ -63,6 +63,7 @@ sub setUp {
 	$self->{__original_cwd} = getcwd();
 
 	my $root = tempdir(CLEANUP => 1);
+	$self->{root} = $root;
 	mkdir($root . '/data') or croak("mkdir $root/data failed: $!");
 	mkdir($root . '/cache') or croak("mkdir $root/cache failed: $!");
 	$self->__makeSourceFile($root . '/data', 'core.sqlite.gz', ['asv', 'kjv']);
@@ -83,6 +84,7 @@ sub tearDown {
 
 	chdir($self->{__original_cwd}) if (defined($self->{__original_cwd}));
 	$self->{__original_cwd} = undef;
+	$self->{root} = undef;
 
 	return $self->SUPER::tearDown();
 }
@@ -102,6 +104,24 @@ sub testFallbackToCoreWhenNoSingleFile {
 	my $sut = Chleb::Bible->new({ translation => 'asv' })->__backend;
 	is($sut->__makeSourceCompressedPath(), $sut->dataDir . '/core.sqlite.gz',
 		'falls back to the multi-translation core file');
+
+	return EXIT_SUCCESS;
+}
+
+sub testSourceInspectionDoesNotUseSystemTempDirectory {
+	my ($self) = @_;
+	plan tests => 1;
+
+	local $ENV{TMPDIR} = $self->{root} . '/not-a-directory';
+	unlink($self->{root} . '/cache/kjv.sqlite') if (-f $self->{root} . '/cache/kjv.sqlite');
+	my $backend = Chleb::Bible::Backend->new({
+		bible    => Chleb::Bible->new({ translation => 'kjv' }),
+		dataDir  => $self->{root} . '/data',
+		cacheDir => $self->{root} . '/cache',
+	});
+
+	is($backend->__makeSourceCompressedPath(), $self->{root} . '/data/kjv.sqlite.gz',
+		'source inspection uses the backend cache for temporary SQLite data');
 
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
We prefer our cache directory, or /var/tmp.
don't use /tmp for bibles because they are too large.