### PR TITLE
🩹 silence expected cross-canon book misses

### DIFF
--- a/lib/Chleb.pm
+++ b/lib/Chleb.pm
@@ -475,7 +475,7 @@ with a different canon fall back to their own verse ordinal.
 sub __getRelatedRandomVerse {
 	my ($self, $bible, $anchorVerse, $verseOrdinal, $args) = @_;
 
-	my $book = $bible->getBookByShortName($anchorVerse->book->shortName, { nonFatal => 1 });
+	my $book = $bible->findBookByShortName($anchorVerse->book->shortName);
 	if ($book) {
 		my $chapter = $book->getChapterByOrdinal($anchorVerse->chapter->ordinal, { nonFatal => 1 });
 		return if (!$chapter);

--- a/lib/Chleb/Bible.pm
+++ b/lib/Chleb/Bible.pm
@@ -165,6 +165,10 @@ in the key C<nonFatal> within the B<optional> C<$args> C<HASH>.
 sub getBookByShortName {
 	my ($self, $shortName, $args) = @_;
 
+	if (my $book = $self->findBookByShortName($shortName)) {
+		return $book;
+	}
+
 	my $closestBook;
 	my $lowestDistance = $Chleb::Constants::UINT_MAX; # an impossibly high number, all mismatches will be lower
 	my @books = shuffle(@{ $self->books }); # be fair; don't bias against books near the end of the bible
@@ -174,9 +178,6 @@ sub getBookByShortName {
 			$lowestDistance = $distance;
 			$closestBook = $book;
 		}
-
-		next unless ($book->equals($shortName));
-		return $book;
 	}
 
 	my $errorMsg = "Short book name '$shortName' is not a book in the bible, did you mean "
@@ -186,6 +187,23 @@ sub getBookByShortName {
 		$self->dic->logger->warn($errorMsg);
 	} else {
 		croak(Chleb::Exception->raise(HTTP_NOT_FOUND, $errorMsg));
+	}
+
+	return;
+}
+
+=item C<findBookByShortName($shortName)>
+
+Return a L<Chleb::Bible::Book> object from L</books> given its C<$shortName>, or
+C<undef> if the book does not exist.  An unsuccessful lookup is not logged.
+
+=cut
+
+sub findBookByShortName {
+	my ($self, $shortName) = @_;
+
+	foreach my $book (@{ $self->books }) {
+		return $book if ($book->equals($shortName));
 	}
 
 	return;
@@ -358,7 +376,7 @@ sub resolveBook {
 		if (looks_like_number($book)) {
 			$book = $self->getBookByOrdinal($book);
 		} else {
-			if (my $shortBook = $self->getBookByShortName($book, { nonFatal => 1 })) {
+			if (my $shortBook = $self->findBookByShortName($book)) {
 				return $shortBook;
 			} else {
 				$book = $self->getBookByLongName($book);

--- a/t/Bible_getBookByShortName.t
+++ b/t/Bible_getBookByShortName.t
@@ -104,10 +104,34 @@ sub testNotFound {
 
 sub testNotFoundNonFatal {
 	my ($self) = @_;
-	plan tests => 1;
+	plan tests => 2;
 
 	my @bible = $self->sut->__getBible();
 	is($bible[0]->getBookByShortName('jes', { nonFatal => 1 }), undef, '<undef> returned');
+	$bible[0]->dic->logger->isLogged(qr/Short[ ]book[ ]name[ ]'jes'[ ]is[ ]not[ ]a[ ]book/x);
+
+	return EXIT_SUCCESS;
+}
+
+sub testFindNotFound {
+	my ($self) = @_;
+	plan tests => 2;
+
+	my @bible = $self->sut->__getBible();
+	my $messageCount = scalar(@{ $bible[0]->dic->logger->__messages });
+	is($bible[0]->findBookByShortName('jes'), undef, '<undef> returned');
+	is(scalar(@{ $bible[0]->dic->logger->__messages }), $messageCount, 'unsuccessful find is not logged');
+
+	return EXIT_SUCCESS;
+}
+
+sub testFindSuccess {
+	my ($self) = @_;
+	plan tests => 1;
+
+	my @bible = $self->sut->__getBible();
+	my $book = $bible[0]->findBookByShortName('prov');
+	is($book->shortName, 'prov', 'shortName is prov');
 
 	return EXIT_SUCCESS;
 }

--- a/t/random.t
+++ b/t/random.t
@@ -83,7 +83,7 @@ sub test {
 sub testMultipleTranslationsRetryUnavailableVerse {
 	my ($self) = @_;
 	plan skip_all => 'Pickthall test data is not installed' unless $self->hasTranslation('pickthall');
-	plan tests => 2;
+	plan tests => 3;
 
 	my $verses = $self->sut->random({ version => 2, translations => ['kjv', 'pickthall'] });
 	my %translations = map { $_->book->bible->translation() => 1 } @{ $verses };
@@ -94,6 +94,11 @@ sub testMultipleTranslationsRetryUnavailableVerse {
 	is_deeply([ sort keys %translations ], [ 'kjv', 'pickthall' ], 'random returns both requested translations');
 	cmp_ok($pickthallVerse->ordinal, '<=', $self->sut->bibles('pickthall')->verseCount,
 		'random retries until the verse is available in every translation');
+	is(
+		scalar(grep { /Short[ ]book[ ]name/x } @{ $self->sut->dic->logger->__messages }),
+		0,
+		'cross-canon random fallback does not warn about an absent book',
+	);
 
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Introduce findBookByShortName() for quiet existence checks while preserving getBookByShortName() for strict lookups and explicitly requested non-fatal warnings.

Use the new method when random verses cross translation canons and when resolveBook() probes short names before long names. This prevents expected misses, such as Genesis in the Pickthall Quran, from producing operational warnings while retaining warnings for callers that deliberately request them.

This adds a new public method to Chleb::Bible and therefore changes the library API. Do not merge this commit into rel/3.0; it belongs on a later release line.