### PR TITLE
🔒️ redact secrets from config traces

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -384,6 +384,7 @@ t/Utils_limitText.t
 t/Utils_OSError_Mapper.t
 t/Utils_parseIntoType.t
 t/Utils_queryParamsHelper.t
+t/Utils_redactConfigValue.t
 t/Utils_removeArrayEmptyItems.t
 t/Utils_SecureString.t
 t/verse.t

--- a/lib/Chleb/DI/Config.pm
+++ b/lib/Chleb/DI/Config.pm
@@ -50,7 +50,6 @@ C<tokens.yaml> are merged over it when present.
 =cut
 
 use Chleb::Utils;
-use Data::Dumper;
 use English qw(-no_match_vars);
 use IO::File;
 use Readonly;
@@ -125,8 +124,12 @@ sub get {
 		isBoolean    => $isBoolean,
 		pDefaultUsed => \$defaultUsed,
 	});
-	my $valuePrintable = (defined($value) && ref($value)) ? (Dumper $value) : $value;
-	my $defaultPrintable = (defined($default) && ref($default)) ? (Dumper $default) : $default;
+	my $valuePrintable = Chleb::Utils::redactConfigValue($key, $value);
+	$valuePrintable = Chleb::Utils::redactingDumper($valuePrintable)
+	    if (defined($valuePrintable) && ref($valuePrintable));
+	my $defaultPrintable = Chleb::Utils::redactConfigValue($key, $default);
+	$defaultPrintable = Chleb::Utils::redactingDumper($defaultPrintable)
+	    if (defined($defaultPrintable) && ref($defaultPrintable));
 	my $msg = sprintf('[%s] %s: %s (default %s)', $section, $key, $valuePrintable, $defaultPrintable);
 
 	my $level = 'trace';
@@ -195,18 +198,20 @@ sub __get {
 			foreach my $k (keys(%allKeys)) {
 				my $v;
 				if (exists($self->__data->{$section}->{$key}->{$k})) {
-					$self->dic->logger->trace(Dumper $self->__data);
+					$self->dic->logger->trace(Chleb::Utils::redactingDumper($self->__data));
 					$v = $self->__data->{$section}->{$key}->{$k};
-					$self->dic->logger->trace("$section -> $key -> $k: '$v' (from real config)");
+					my $printableValue = Chleb::Utils::redactConfigValue($k, $v);
+					$self->dic->logger->trace("$section -> $key -> $k: '$printableValue' (from real config)");
 				} else {
 					$v = $default->{$k};
-					$self->dic->logger->trace("$section -> $key -> $k: '$v' (from default)");
+					my $printableValue = Chleb::Utils::redactConfigValue($k, $v);
+					$self->dic->logger->trace("$section -> $key -> $k: '$printableValue' (from default)");
 				}
 
 				$ephemeralSection{$k} = $v;
 			}
 
-			$self->dic->logger->trace('Ephemeral section content: ' . Dumper \%ephemeralSection);
+			$self->dic->logger->trace('Ephemeral section content: ' . Chleb::Utils::redactingDumper(\%ephemeralSection));
 			return \%ephemeralSection;
 		}
 

--- a/lib/Chleb/DI/MockLogger.pm
+++ b/lib/Chleb/DI/MockLogger.pm
@@ -64,6 +64,21 @@ sub isLogged {
 	return $result;
 }
 
+sub isNotLogged {
+	my ($self, $regEx) = @_;
+
+	my $result = 1;
+	foreach my $msg (@{ $self->__messages }) {
+		if ($msg =~ m/$regEx/x) {
+			$result = 0;
+			last;
+		}
+	}
+
+	ok($result, "NOT LOGGED: $regEx");
+	return $result;
+}
+
 sub info {
 	my ($self, $msg) = @_;
 	return $self->log($msg);

--- a/lib/Chleb/Utils.pm
+++ b/lib/Chleb/Utils.pm
@@ -16,6 +16,7 @@ Functions for miscellaneous internal purposes
 use Chleb::Utils::BooleanParserSystemException;
 use Chleb::Utils::BooleanParserUserException;
 use Chleb::Utils::TypeParserException;
+use Data::Dumper;
 use English qw(-no_match_vars);
 use HTTP::Status qw(:constants);
 use Readonly;
@@ -48,6 +49,14 @@ The maximum length of a string returned by L</limitText($text)>.
 =cut
 
 Readonly my $MAX_TEXT_LENGTH => 120;
+
+=item C<$REDACT_CONFIG_KEY_PATTERN>
+
+Pattern matching configuration keys whose values must not be exposed.
+
+=cut
+
+Readonly my $REDACT_CONFIG_KEY_PATTERN => qr{ secret }ix;
 
 =back
 
@@ -168,6 +177,34 @@ sub removeArrayEmptyItems {
 	}
 
 	return $filteredCount == 0 ? $arrayRef : \@filtered;
+}
+
+=item C<redactConfigValue($key, $value)>
+
+Return C<'***'> when C<$key> identifies a secret configuration value.
+Otherwise, return C<$value> unmodified.
+
+=cut
+
+sub redactConfigValue {
+	my ($key, $value) = @_;
+
+	return '***' if (defined($key) && $key =~ $REDACT_CONFIG_KEY_PATTERN);
+	return $value;
+}
+
+=item C<redactingDumper($value)>
+
+Return a L<Data::Dumper> representation of C<$value> after recursively copying
+the structure and replacing values whose hash keys identify secrets with
+C<'***'>.  The original structure is not modified.
+
+=cut
+
+sub redactingDumper {
+	my ($value) = @_;
+
+	return Dumper __redactConfigStructure($value);
 }
 
 sub queryParamsHelper {
@@ -393,6 +430,39 @@ sub colorIndexFromWord {
 	}
 
 	return $h & 63; # low 6 bits => 0..63
+}
+
+=back
+
+=head1 PRIVATE FUNCTIONS
+
+=over
+
+=item C<__redactConfigStructure($value, [$key])>
+
+Recursively copy configuration data, redacting values associated with matching
+hash keys.  Arrays are copied and traversed so hashes nested within them are
+also redacted.
+
+=cut
+
+sub __redactConfigStructure {
+	my ($value, $key) = @_;
+
+	return redactConfigValue($key, $value)
+	    if (defined($key) && $key =~ $REDACT_CONFIG_KEY_PATTERN);
+
+	if (ref($value) eq 'HASH') {
+		return {
+			map { $_ => __redactConfigStructure($value->{$_}, $_) } keys(%$value)
+		};
+	}
+
+	if (ref($value) eq 'ARRAY') {
+		return [ map { __redactConfigStructure($_) } @$value ];
+	}
+
+	return $value;
 }
 
 =back

--- a/t/Config_get.t
+++ b/t/Config_get.t
@@ -72,6 +72,8 @@ warning_equal:
 Dancer2:
   public_dir: data/static/public
 session_tokens:
+  backend_jwt:
+    secret: unit-test-secret
   backend_redis:
     db: 5
     host: redis-82.example.net
@@ -161,6 +163,21 @@ sub testSubsectionHash_default {
 		host => 'redis-82.example.net',
 		nonExist => $default,
 	}, 'key not set - returning default within subsection') or diag(explain($subsection));
+
+	return EXIT_SUCCESS;
+}
+
+sub testSubsectionSecretRedacted {
+	my ($self) = @_;
+	plan tests => 3;
+
+	my $subsection = $self->sut->get('session_tokens', 'backend_jwt', { secret => undef });
+	is($subsection->{secret}, 'unit-test-secret', 'secret is returned to the caller');
+
+	$self->sut->dic->logger->isNotLogged(qr{ \Qunit-test-secret\E }x);
+	$self->sut->dic->logger->isLogged(
+		qr{ secret: [ ] '\Q***\E' [ ] \(from [ ] real [ ] config\) }x,
+	);
 
 	return EXIT_SUCCESS;
 }

--- a/t/Utils_redactConfigValue.t
+++ b/t/Utils_redactConfigValue.t
@@ -1,0 +1,76 @@
+#!/usr/bin/env perl
+# Chleb Bible Search
+# Copyright (c) 2024-2026, Rev. Duncan Ross Palmer (M6KVM, 2E0EOL),
+# All rights reserved.
+
+package UtilsRedactConfigValueTests;
+## no critic (Modules::RequireEndWithOne)
+## no critic (Modules::RequireFilenameMatchesPackage)
+## no critic (Modules::ProhibitMultiplePackages)
+use strict;
+use warnings;
+use Moose;
+
+use lib 'externals/libtest-module-runnable-perl/lib';
+
+extends 'Test::Module::Runnable';
+
+use Chleb::Utils;
+use POSIX qw(EXIT_SUCCESS);
+use Test::More 0.96;
+
+sub testNonSecretUnchanged {
+	my ($self) = @_;
+	plan tests => 2;
+
+	is(Chleb::Utils::redactConfigValue('issuer', 'chleb'), 'chleb', 'ordinary value is unchanged');
+	is(Chleb::Utils::redactConfigValue(undef, 'chleb'), 'chleb', 'value without a key is unchanged');
+
+	return EXIT_SUCCESS;
+}
+
+sub testSecretRedacted {
+	my ($self) = @_;
+	plan tests => 4;
+
+	is(Chleb::Utils::redactConfigValue('secret', 'sensitive'), '***', 'secret is redacted');
+	is(Chleb::Utils::redactConfigValue('SECRET', 'sensitive'), '***', 'matching is case insensitive');
+	is(Chleb::Utils::redactConfigValue('client_secret', 'sensitive'), '***', 'compound secret key is redacted');
+	is(Chleb::Utils::redactConfigValue('secret', { nested => 'sensitive' }), '***', 'entire secret structure is redacted');
+
+	return EXIT_SUCCESS;
+}
+
+sub testRedactingDumper {
+	my ($self) = @_;
+	plan tests => 6;
+
+	my $input = {
+		public => 'visible',
+		nested => {
+			secret => 'hidden',
+		},
+		list => [
+			{ client_secret => 'also-hidden' },
+			'ordinary',
+		],
+	};
+	my $dump = Chleb::Utils::redactingDumper($input);
+
+	like($dump, qr{ \Q'public' => 'visible'\E }x, 'ordinary hash value is dumped');
+	like($dump, qr{ \Q'secret' => '***'\E }x, 'nested secret is redacted');
+	like($dump, qr{ \Q'client_secret' => '***'\E }x, 'secret nested within an array is redacted');
+	unlike($dump, qr{ \Qhidden\E }x, 'nested secret content is absent');
+	is($input->{nested}->{secret}, 'hidden', 'source hash is not modified');
+	is($input->{list}->[0]->{client_secret}, 'also-hidden', 'source array content is not modified');
+
+	return EXIT_SUCCESS;
+}
+
+__PACKAGE__->meta->make_immutable;
+
+package main;
+use strict;
+use warnings;
+
+exit(UtilsRedactConfigValueTests->new->run());


### PR DESCRIPTION
Add key-aware scalar redaction and a deep redacting Dumper which sanitizes a copied configuration structure without modifying values returned to callers.

Use the redacting functions for scalar, default, full-config, and ephemeral-section trace messages so keys matching secret cannot leak through nested hashes or arrays. Add focused utility and config-boundary regression coverage.