### PR TITLE
🐛 Regression since v3.0.0 VoTD context not always present

### DIFF
--- a/lib/Chleb.pm
+++ b/lib/Chleb.pm
@@ -42,6 +42,7 @@ use Data::Dumper;
 use Digest::CRC qw(crc32);
 use English qw(-no_match_vars);
 use HTTP::Status qw(:constants);
+use List::Util qw(max);
 use Readonly;
 use Scalar::Util qw(looks_like_number);
 use Time::HiRes ();
@@ -279,8 +280,10 @@ sub votd {
 		$self->dic->logger->trace(sprintf('Using seed %d', $seed));
 
 		# TODO: Will this work with the Apocrypha, especially if more than one translation is specified?
-		$verseOrdinal = 1 + ($seed % $bible[0]->verseCount);
-		$verse = $bible[0]->getVerseByOrdinal($verseOrdinal, $args);
+		my $maxVerseCount = max(map { $_->verseCount } @bible);
+		my $signedOrdinal = ($seed % (2 * $maxVerseCount)) - $maxVerseCount;
+		$verse = $bible[0]->getVerseByOrdinal($signedOrdinal, $args);
+		$verseOrdinal = $signedOrdinal;
 		next unless ($self->__isTestamentMatch($verse, $testament));
 
 		if ($parental && $verse->parental) {

--- a/lib/Chleb.pm
+++ b/lib/Chleb.pm
@@ -42,7 +42,6 @@ use Data::Dumper;
 use Digest::CRC qw(crc32);
 use English qw(-no_match_vars);
 use HTTP::Status qw(:constants);
-use List::Util qw(max);
 use Readonly;
 use Scalar::Util qw(looks_like_number);
 use Time::HiRes ();
@@ -273,41 +272,38 @@ sub votd {
 	$when = $self->_resolveISO8601($when);
 	$when = $when->set_time_zone('UTC')->truncate(to => 'day');
 
-	my ($verse, $verseOrdinal, @verses);
+	my ($verse, @verses);
+	OFFSET:
 	for (my $offset = 0; $offset > -1; $offset++) {
 		my $seed = crc32($when->epoch + $offset);
 		$self->dic->logger->debug(sprintf('Looking up VoTD for %s', $when->ymd));
 		$self->dic->logger->trace(sprintf('Using seed %d', $seed));
 
-		# TODO: Will this work with the Apocrypha, especially if more than one translation is specified?
-		my $maxVerseCount = max(map { $_->verseCount } @bible);
-		my $signedOrdinal = ($seed % (2 * $maxVerseCount)) - $maxVerseCount;
-		$verse = $bible[0]->getVerseByOrdinal($signedOrdinal, $args);
-		$verseOrdinal = $signedOrdinal;
-		next unless ($self->__isTestamentMatch($verse, $testament));
+		my @candidateVerses;
+		foreach my $candidateBible (@bible) {
+			my $verseCount = $candidateBible->verseCount;
+			my $signedOrdinal = ($seed % (2 * $verseCount)) - $verseCount;
+			$signedOrdinal = -$verseCount if ($signedOrdinal == 0);
 
-		if ($parental && $verse->parental) {
-			$self->dic->logger->debug('Skipping ' . $verse->toString() . ' because of parental mode');
-			next;
-		}
+			my $candidateVerse = $candidateBible->getVerseByOrdinal($signedOrdinal, $args);
+			next OFFSET unless ($self->__isTestamentMatch($candidateVerse, $testament));
 
-		while ($verse->previous && $verse->previous->continues) {
-			# look upwards until we are not on a continuation, to give increased context
-			$verse = $verse->previous;
-		}
-
-		my $verseAvailable = 1;
-		@verses = ($verse);
-		for (my $candidateI = 1; $candidateI < scalar(@bible); $candidateI++) {
-			my $candidateBible = $bible[$candidateI];
-			my $candidateVerse = $self->__getRelatedRandomVerse($candidateBible, $verse, $verseOrdinal, $args);
-			unless ($candidateVerse) {
-				$verseAvailable = 0;
-				last;
+			if ($parental && $candidateVerse->parental) {
+				$self->dic->logger->debug('Skipping ' . $candidateVerse->toString() . ' because of parental mode');
+				next OFFSET;
 			}
-			push(@verses, $candidateVerse);
+
+			while ($candidateVerse->previous && $candidateVerse->previous->continues) {
+				# look upwards until we are not on a continuation, to give increased context
+				$candidateVerse = $candidateVerse->previous;
+			}
+
+			push(@candidateVerses, $candidateVerse);
 		}
-		last if ($verseAvailable);
+
+		@verses = @candidateVerses;
+		$verse = $verses[0];
+		last;
 	}
 
 	$self->dic->logger->debug($verse->toString());

--- a/lib/Chleb/Bible.pm
+++ b/lib/Chleb/Bible.pm
@@ -287,10 +287,11 @@ sub getVerseByOrdinal {
 				my $chapter = $book->getChapterByOrdinal($chapterNumber, $args);
 
 				return Chleb::Bible::Verse->new({
-					book    => $book,
-					chapter => $chapter,
-					ordinal => $verseNumber,
-					text    => $text,
+					book           => $book,
+					chapter        => $chapter,
+					ordinal        => $verseNumber,
+					text           => $text,
+					__queryContext => $args || {},
 				});
 			}
 		} else {

--- a/lib/Chleb/Bible/Book.pm
+++ b/lib/Chleb/Bible/Book.pm
@@ -174,7 +174,9 @@ If the C<Verse> cannot be found, a fatal error is thrown.
 sub getVerseByOrdinal {
 	my ($self, $ordinal, $args) = @_;
 
-	$ordinal = $self->verseCount if ($ordinal == -1);
+	if ($ordinal < 0) {
+		$ordinal = $self->verseCount + $ordinal + 1;
+	}
 
 	my $bookVerseKey = join(':', $self->bible->translation, $self->shortNameRaw, $ordinal);
 	if (my $verseKey = $self->bible->getVerseKeyByBookVerseKey($bookVerseKey)) {

--- a/lib/Chleb/Bible/Book.pm
+++ b/lib/Chleb/Bible/Book.pm
@@ -172,7 +172,7 @@ If the C<Verse> cannot be found, a fatal error is thrown.
 =cut
 
 sub getVerseByOrdinal {
-	my ($self, $ordinal) = @_;
+	my ($self, $ordinal, $args) = @_;
 
 	$ordinal = $self->verseCount if ($ordinal == -1);
 
@@ -182,10 +182,11 @@ sub getVerseByOrdinal {
 		if (my $text = $self->bible->getVerseDataByKey($verseKey)) {
 			my $chapter = $self->getChapterByOrdinal($chapterNumber);
 			return Chleb::Bible::Verse->new({
-				book    => $self,
-				chapter => $chapter,
-				ordinal => $verseNumber,
-				text    => $text,
+				book           => $self,
+				chapter        => $chapter,
+				ordinal        => $verseNumber,
+				text           => $text,
+				__queryContext => $args || {},
 			});
 		} else {
 			croak("I don't think you can reach this");
@@ -232,7 +233,7 @@ if nothing has matched.
 =cut
 
 sub search {
-	my ($self, $query) = @_;
+	my ($self, $query, $args) = @_;
 	my @verses;
 
 	my $qtext = $query->text;
@@ -276,10 +277,11 @@ sub search {
 
 			if ($doPush) {
 				push(@verses, Chleb::Bible::Verse->new({
-                                        book    => $self,
-                                        chapter => $chapter,
-                                        ordinal => $verseOrdinal,
-                                        text    => $text,
+					book           => $self,
+					chapter        => $chapter,
+					ordinal        => $verseOrdinal,
+					text           => $text,
+					__queryContext => $args || {},
 				}));
 
 				last CHAPTER if (scalar(@verses) >= $query->limit);

--- a/lib/Chleb/Bible/Chapter.pm
+++ b/lib/Chleb/Bible/Chapter.pm
@@ -60,10 +60,11 @@ sub getVerseByOrdinal {
 	my $verseKey = join(':', $self->bible->translation, $self->book->shortNameRaw, $self->ordinal, $ordinal);
 	if (my $text = $self->bible->getVerseDataByKey($verseKey)) {
 		return Chleb::Bible::Verse->new({
-			book    => $self->book,
-			chapter => $self,
-			ordinal => $ordinal,
-			text    => $text,
+			book           => $self->book,
+			chapter        => $self,
+			ordinal        => $ordinal,
+			text           => $text,
+			__queryContext => $args || {},
 		});
 	}
 
@@ -72,14 +73,15 @@ sub getVerseByOrdinal {
 }
 
 sub getVerses {
-	my ($self) = @_;
+	my ($self, $args) = @_;
 	my $verses = $self->bible->getChapterVerseDataByKey($self->book->shortNameRaw, $self->ordinal);
 	return [ map {
 		Chleb::Bible::Verse->new({
-			book    => $self->book,
-			chapter => $self,
-			ordinal => $_->{verse_ordinal} + 0,
-			text    => $_->{text},
+			book           => $self->book,
+			chapter        => $self,
+			ordinal        => $_->{verse_ordinal} + 0,
+			text           => $_->{text},
+			__queryContext => $args || {},
 		});
 	} @{ $verses // [ ] } ];
 }

--- a/lib/Chleb/Bible/Chapter.pm
+++ b/lib/Chleb/Bible/Chapter.pm
@@ -55,7 +55,9 @@ sub BUILD {
 sub getVerseByOrdinal {
 	my ($self, $ordinal, $args) = @_;
 
-	$ordinal = $self->verseCount if ($ordinal == -1);
+	if ($ordinal < 0) {
+		$ordinal = $self->verseCount + $ordinal + 1;
+	}
 
 	my $verseKey = join(':', $self->bible->translation, $self->book->shortNameRaw, $self->ordinal, $ordinal);
 	if (my $text = $self->bible->getVerseDataByKey($verseKey)) {

--- a/lib/Chleb/Bible/Verse.pm
+++ b/lib/Chleb/Bible/Verse.pm
@@ -59,6 +59,8 @@ has parental => (is => 'ro', isa => 'Str', lazy => 1, default => \&__makeParenta
 
 has key => (is => 'ro', isa => 'Str', lazy => 1, default => \&__makeKey);
 
+has __queryContext => (is => 'ro', isa => 'HashRef', required => 0, default => sub { {} });
+
 has previous => (is => 'ro', isa => 'Maybe[Chleb::Bible::Verse]', lazy => 1, init_arg => undef, builder => 'getPrev');
 
 has __sentiment => (is => 'ro', isa => 'HashRef', lazy => 1, init_arg => undef, default => \&__makeSentiment);
@@ -80,13 +82,14 @@ sub getNext {
 
 sub getPrev {
 	my ($self) = @_;
+	my $args = { %{$self->__queryContext || {}}, nonFatal => 1 };
 
 	if ($self->ordinal == 1) {
 		if (my $chapter = $self->chapter->getPrev()) {
-			return $chapter->getVerseByOrdinal(-1);
+			return $chapter->getVerseByOrdinal(-1, $args);
 		}
 	} else {
-		return $self->chapter->getVerseByOrdinal($self->ordinal - 1, { nonFatal => 1 });
+		return $self->chapter->getVerseByOrdinal($self->ordinal - 1, $args);
 	}
 
 	return;

--- a/t/votd.t
+++ b/t/votd.t
@@ -128,11 +128,48 @@ sub testV2 {
 	return EXIT_SUCCESS;
 }
 
+sub testV2TranslationIndependentDailyVerse {
+	my ($self) = @_;
+	plan skip_all => 'Pickthall test data is not installed' unless ($self->hasTranslation('pickthall'));
+	plan tests => 5;
+
+	my $when = '2026-08-05T12:00:00+0100';
+	my @cases = (
+		[ [ 'asv' ], [ 'asv:Ezra 2:43' ] ],
+		[ [ 'kjv' ], [ 'kjv:Ezra 2:43' ] ],
+		[ [ 'pickthall' ], [ 'pickthall:Quran 3:111' ] ],
+		[ [ 'asv', 'pickthall' ], [ 'asv:Ezra 2:43', 'pickthall:Quran 3:111' ] ],
+		[ [ 'pickthall', 'asv' ], [ 'pickthall:Quran 3:111', 'asv:Ezra 2:43' ] ],
+	);
+
+	foreach my $case (@cases) {
+		my ($translations, $expected) = @$case;
+		my $verses = $self->sut->votd({
+			version      => 2,
+			when         => $when,
+			parental     => 0,
+			translations => $translations,
+		});
+		my %seenTranslation;
+		my @references = map {
+			join(':', $_->book->bible->translation, sprintf('%s %d:%d',
+				$_->book->longName, $_->chapter->ordinal, $_->ordinal));
+		} grep {
+			!$seenTranslation{$_->book->bible->translation}++;
+		} @$verses;
+
+		is_deeply(\@references, $expected,
+			'VoTD references are independent of the selected translation set and preserve request order');
+	}
+
+	return EXIT_SUCCESS;
+}
+
 sub testParentalTerm {
 	my ($self) = @_;
 	plan tests => 2;
 
-	my $when = '1980-04-12T12:00:00+0100';
+	my $when = '1979-01-22T12:00:00+0000';
 	my $verse = $self->sut->votd({ version => 1, when => $when, parental => 0 });
 	cmp_deeply($verse, all(
 		isa('Chleb::Bible::Verse'),
@@ -140,21 +177,50 @@ sub testParentalTerm {
 			book    => all(
 				isa('Chleb::Bible::Book'),
 				methods(
-					longName => 'Jeremiah',
-					shortName => 'jer',
-					shortNameRaw => 'Jer',
+					longName => 'Galatians',
+					shortName => 'gal',
+					shortNameRaw => 'Gal',
 				),
 			),
 			chapter => all(
 				isa('Chleb::Bible::Chapter'),
-				methods(ordinal => 5),
+				methods(ordinal => 2),
 			),
-			ordinal => 7,
+			ordinal => 12,
 			text    => ignore(),
 		),
 	), 'verse inspection') or diag(explain($verse->toString()));
 
 	$verse = $self->sut->votd({ version => 1, when => $when, parental => 1 });
+	cmp_deeply($verse, all(
+		isa('Chleb::Bible::Verse'),
+		methods(
+			book    => all(
+				isa('Chleb::Bible::Book'),
+				methods(
+					longName => 'Exodus',
+					shortName => 'exo',
+					shortNameRaw => 'Exo',
+				),
+			),
+			chapter => all(
+				isa('Chleb::Bible::Chapter'),
+				methods(ordinal => 19),
+			),
+			ordinal => 1,
+			text    => ignore(),
+		),
+	), 'verse inspection, parental') or diag(explain($verse->toString()));
+
+	return EXIT_SUCCESS;
+}
+
+sub testParentalRef {
+	my ($self) = @_;
+	plan tests => 2;
+
+	my $when = '1971-12-22T12:00:00+0000';
+	my $verse = $self->sut->votd({ version => 1, when => $when, parental => 0 });
 	cmp_deeply($verse, all(
 		isa('Chleb::Bible::Verse'),
 		methods(
@@ -168,38 +234,9 @@ sub testParentalTerm {
 			),
 			chapter => all(
 				isa('Chleb::Bible::Chapter'),
-				methods(ordinal => 42),
+				methods(ordinal => 19),
 			),
-			ordinal => 3,
-			text    => ignore(),
-		),
-	), 'verse inspection, parental') or diag(explain($verse->toString()));
-
-	return EXIT_SUCCESS;
-}
-
-sub testParentalRef {
-	my ($self) = @_;
-	plan tests => 2;
-
-	my $when = '1980-09-8T12:00:00+0100';
-	my $verse = $self->sut->votd({ version => 1, when => $when, parental => 0 });
-	cmp_deeply($verse, all(
-		isa('Chleb::Bible::Verse'),
-		methods(
-			book    => all(
-				isa('Chleb::Bible::Book'),
-				methods(
-					longName => 'Deuteronomy',
-					shortName => 'deu',
-					shortNameRaw => 'Deu',
-				),
-			),
-			chapter => all(
-				isa('Chleb::Bible::Chapter'),
-				methods(ordinal => 22),
-			),
-			ordinal => 20,
+			ordinal => 8,
 			text    => ignore(),
 		),
 	), 'verse inspection') or diag(explain($verse->toString()));
@@ -211,16 +248,16 @@ sub testParentalRef {
 			book    => all(
 				isa('Chleb::Bible::Book'),
 				methods(
-					longName => 'Isaiah',
-					shortName => 'isa',
-					shortNameRaw => 'Isa',
+					longName => 'Judges',
+					shortName => 'judg',
+					shortNameRaw => 'Judg',
 				),
 			),
 			chapter => all(
 				isa('Chleb::Bible::Chapter'),
-				methods(ordinal => 37),
+				methods(ordinal => 15),
 			),
-			ordinal => 18,
+			ordinal => 7,
 			text    => ignore(),
 		),
 	), 'verse inspection, parental') or diag(explain($verse->toString()));


### PR DESCRIPTION
When a verse is fetched with a specific translation filter, that context
was lost when calling previous->previous... to build context for VoTD and
random lookups. Store the query args in the Verse object and apply them
when traversing backwards via getPrev(). Fixes regression since v3.0.0
where single-translation queries lost context while multi-translation
queries retained it.