### PR TITLE
🐛 remove duplicate lookup ordinal validation

### DIFF
--- a/lib/Chleb/Server/Dancer2.pm
+++ b/lib/Chleb/Server/Dancer2.pm
@@ -704,27 +704,6 @@ sub __validateLookupOrdinals {
 	return;
 }
 
-=head1 __validateLookupOrdinals($chapter, $verse)
-
-Reject malformed lookup path ordinals before they reach numeric Bible APIs.
-
-=cut
-
-sub __validateLookupOrdinals {
-	my ($chapter, $verse) = @_;
-
-	foreach my $ordinal ([ 'chapter', $chapter ], [ 'verse', $verse ]) {
-		next unless (defined($ordinal->[1]));
-		next if ($ordinal->[1] =~ m{\A-?\d+\z}x);
-		croak(Chleb::Exception->raise(
-			HTTP_NOT_FOUND,
-			sprintf("Invalid %s ordinal '%s'", $ordinal->[0], $ordinal->[1]),
-		));
-	}
-
-	return;
-}
-
 =head1 __isTemplateMarker($line)
 
 Return true when a source line is the case-insensitive Chleb template marker.
@@ -1192,7 +1171,6 @@ get '/1/lookup/:book/:chapter' => sub {
 	my $evalOk6; $evalOk6 = eval {
 		__validateLookupOrdinals($chapter);
 		$accept = Chleb::Server::MediaType->parseAcceptHeader($dancerRequest->header('Accept'));
-		__validateLookupOrdinals($chapter);
 		$result = $server->__lookup({
 			accept       => $accept,
 			book         => $book,
@@ -1240,7 +1218,6 @@ get '/1/lookup/:book/:chapter/:verse' => sub {
 	my $evalOk7; $evalOk7 = eval {
 		__validateLookupOrdinals($chapter, $verse);
 		$accept = Chleb::Server::MediaType->parseAcceptHeader($dancerRequest->header('Accept'));
-		__validateLookupOrdinals($chapter, $verse);
 		$result = $server->__lookup({
 			accept       => $accept,
 			book         => $book,

--- a/t/Server_Dancer2_notFound.t
+++ b/t/Server_Dancer2_notFound.t
@@ -46,6 +46,7 @@ use Chleb::Server::Dancer2;
 use Chleb::Server::MediaType;
 use English qw(-no_match_vars);
 use HTTP::Request::Common qw(GET);
+use HTTP::Status qw(HTTP_BAD_REQUEST);
 use Plack::Test;
 use POSIX qw(EXIT_SUCCESS);
 use Test::More 0.96;
@@ -103,7 +104,7 @@ sub testHtmlInternalServerErrorPage {
 	return EXIT_SUCCESS;
 }
 
-sub testMalformedLookupOrdinalIsNotFound {
+sub testMalformedLookupOrdinalIsBadRequest {
 	my ($self) = @_;
 	plan tests => 4;
 
@@ -115,7 +116,7 @@ sub testMalformedLookupOrdinalIsNotFound {
 		my $exception = $EVAL_ERROR;
 
 		isa_ok($exception, 'Chleb::Exception', "malformed $ordinals->[2] raises a Chleb exception");
-		is($exception->statusCode(), 404, "malformed $ordinals->[2] is not found");
+		is($exception->statusCode(), HTTP_BAD_REQUEST, "malformed $ordinals->[2] is a bad request");
 	}
 
 	return EXIT_SUCCESS;

--- a/t/Server_Dancer2_preferredTranslations.t
+++ b/t/Server_Dancer2_preferredTranslations.t
@@ -44,6 +44,7 @@ extends 'Test::Module::Runnable';
 
 use English qw(-no_match_vars);
 use Chleb::Server::Dancer2;
+use HTTP::Status qw(HTTP_BAD_REQUEST);
 use POSIX qw(EXIT_SUCCESS);
 use Test::More 0.96;
 
@@ -99,15 +100,21 @@ sub testLookupBookFallback {
 
 sub testLookupOrdinalValidation {
 	my ($self) = @_;
-	plan tests => 1;
+	plan tests => 4;
 
-	my $error;
-	eval {
-		Chleb::Server::Dancer2::__validateLookupOrdinals('6&translations=all');
-		1;
-	} or $error = $EVAL_ERROR;
+	foreach my $ordinals (
+		[ '6&translations=all' ],
+		[ 6, '7&translations=all' ],
+	) {
+		my $error;
+		eval {
+			Chleb::Server::Dancer2::__validateLookupOrdinals(@$ordinals);
+			1;
+		} or $error = $EVAL_ERROR;
 
-	isa_ok($error, 'Chleb::Exception', 'malformed lookup ordinal returns a Chleb exception');
+		isa_ok($error, 'Chleb::Exception', 'malformed lookup ordinal returns a Chleb exception');
+		is($error->statusCode, HTTP_BAD_REQUEST, 'malformed lookup ordinal returns HTTP 400 Bad Request');
+	}
 
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Keep malformed chapter and verse ordinals on the HTTP 400 path and add regression coverage for both values.