### PR TITLE
🐛 keep Bible VoTD references stable

### DIFF
--- a/lib/Chleb.pm
+++ b/lib/Chleb.pm
@@ -275,6 +275,7 @@ sub votd {
 	$self->dic->logger->trace('Looking for testament: ' . $testament->toString());
 
 	my (@bible) = $self->__getBible($args);
+	my $anchorBible = $self->__votdAnchorBible();
 	$when = $self->_resolveISO8601($when);
 	$when = $when->set_time_zone('UTC')->truncate(to => 'day');
 
@@ -285,23 +286,28 @@ sub votd {
 		$self->dic->logger->debug(sprintf('Looking up VoTD for %s', $when->ymd));
 		$self->dic->logger->trace(sprintf('Using seed %d', $seed));
 
+		my $anchorVerseCount = $anchorBible->verseCount;
+		my $anchorOrdinal = ($seed % (2 * $anchorVerseCount)) - $anchorVerseCount;
+		$anchorOrdinal = -$anchorVerseCount if ($anchorOrdinal == 0);
+		my $anchorVerse = $anchorBible->getVerseByOrdinal($anchorOrdinal, $args);
+		while ($anchorVerse->previous && $anchorVerse->previous->continues) {
+			$anchorVerse = $anchorVerse->previous;
+		}
+
 		my @candidateVerses;
 		foreach my $candidateBible (@bible) {
-			my $verseCount = $candidateBible->verseCount;
-			my $signedOrdinal = ($seed % (2 * $verseCount)) - $verseCount;
-			$signedOrdinal = -$verseCount if ($signedOrdinal == 0);
-
-			my $candidateVerse = $candidateBible->getVerseByOrdinal($signedOrdinal, $args);
+			my $candidateVerse = $self->__votdVerseForTranslation(
+				$candidateBible,
+				$anchorVerse,
+				$seed,
+				$args,
+			);
+			next OFFSET unless ($candidateVerse);
 			next OFFSET unless ($self->__isTestamentMatch($candidateVerse, $testament));
 
 			if ($parental && $candidateVerse->parental) {
 				$self->dic->logger->debug('Skipping ' . $candidateVerse->toString() . ' because of parental mode');
 				next OFFSET;
-			}
-
-			while ($candidateVerse->previous && $candidateVerse->previous->continues) {
-				# look upwards until we are not on a continuation, to give increased context
-				$candidateVerse = $candidateVerse->previous;
 			}
 
 			push(@candidateVerses, $candidateVerse);
@@ -467,6 +473,51 @@ sub __makeAvailableTranslations {
 	my ($self) = @_;
 	my $bible = $self->bibles($TRANSLATION_DEFAULT);
 	return [ $bible->__backend->getAvailableTranslations() ];
+}
+
+=item C<__votdAnchorBible()>
+
+Return the stable translation used to choose the Bible VoTD reference.  Prefer
+the default translation when it is installed, regardless of which translations
+the caller requested.
+
+=cut
+
+sub __votdAnchorBible {
+	my ($self) = @_;
+	my @translations = $self->__allTranslationsList();
+	my %available = map { $_ => 1 } @translations;
+	my $translation = $available{$TRANSLATION_DEFAULT} ? $TRANSLATION_DEFAULT : $translations[0];
+	return $self->bibles($translation);
+}
+
+=item C<__votdVerseForTranslation($bible, $anchorVerse, $seed, $args)>
+
+Return the VoTD candidate for C<$bible>.  Translations containing the anchor
+book use the anchor's exact chapter and verse.  Translations with an
+incompatible canon use their own deterministic ordinal and context boundary.
+
+=cut
+
+sub __votdVerseForTranslation {
+	my ($self, $bible, $anchorVerse, $seed, $args) = @_;
+
+	my ($book) = grep { $_->equals($anchorVerse->book->shortName) } @{ $bible->books };
+	if ($book) {
+		my $chapter = $book->getChapterByOrdinal($anchorVerse->chapter->ordinal, { nonFatal => 1 });
+		return unless ($chapter);
+		return $chapter->getVerseByOrdinal($anchorVerse->ordinal, { %{$args // {}}, nonFatal => 1 });
+	}
+
+	my $verseCount = $bible->verseCount;
+	my $signedOrdinal = ($seed % (2 * $verseCount)) - $verseCount;
+	$signedOrdinal = -$verseCount if ($signedOrdinal == 0);
+	my $verse = $bible->getVerseByOrdinal($signedOrdinal, $args);
+	while ($verse->previous && $verse->previous->continues) {
+		$verse = $verse->previous;
+	}
+
+	return $verse;
 }
 
 =item C<__getRelatedRandomVerse($bible, $anchorVerse, $verseOrdinal, $args)>

--- a/lib/Chleb/Bible/Backend.pm
+++ b/lib/Chleb/Bible/Backend.pm
@@ -55,6 +55,7 @@ Readonly my $FILE_SIG     => '178d4220-2531-11f1-8c59-ab2e7e0be878';
 Readonly my $FILE_VERSION => 17;
 Readonly my $SHARED_CACHE_FILE => 'shared.bin';
 Readonly my $SHARED_CACHE_FORMAT_VERSION => 1;
+Readonly my $VERSE_ORDINAL_CACHE_VERSION => 2;
 
 Readonly my $OT_COUNT => 39;
 
@@ -863,7 +864,8 @@ sub getVerseKeyByOrdinal {
 		$self->__verseKeyCache->{$cacheKey} = $mapped;
 		return $mapped;
 	}
-	if (my $cached = $self->__sharedCacheGet('versekey', $cacheKey)) {
+	my $sharedCacheKey = join(':', $VERSE_ORDINAL_CACHE_VERSION, $cacheKey);
+	if (my $cached = $self->__sharedCacheGet('versekey', $sharedCacheKey)) {
 		$self->__verseKeyCache->{$cacheKey} = $cached;
 		return $cached;
 	}
@@ -891,7 +893,7 @@ SQL
 	my ($mappedTranslation, $mappedBookShortName, $mappedChapterNumber, $mappedVerseNumber) = split(m{ : }x, $key, 4);
 	$self->__verseKeyOrdinalCache->{$mappedTranslation}->{__ordinalToKey}->{$ordinal} = $key;
 	$self->__verseKeyOrdinalCache->{$mappedTranslation}->{$mappedBookShortName}->{$mappedChapterNumber}->{$mappedVerseNumber} = $ordinal;
-	$self->__sharedCacheSet('versekey', $cacheKey, $key);
+	$self->__sharedCacheSet('versekey', $sharedCacheKey, $key);
 	return $key;
 }
 

--- a/t/Backend_sharedCache_storable.t
+++ b/t/Backend_sharedCache_storable.t
@@ -184,6 +184,19 @@ sub testCorruptSharedCacheIsIgnored {
 	return EXIT_SUCCESS;
 }
 
+sub testLegacyVerseOrdinalCacheIsIgnored {
+	my ($self) = @_;
+	plan tests => 2;
+
+	ok($self->sut->__sharedCacheSet('versekey', 'kjv:1', 'kjv:Gen:1:99'),
+		'legacy unversioned ordinal mapping is stored');
+	my $secondBackend = $self->__makeBackend('kjv');
+	is($secondBackend->getVerseKeyByOrdinal(1), 'kjv:Gen:1:1',
+		'ordinal lookup ignores a legacy unversioned shared-cache mapping');
+
+	return EXIT_SUCCESS;
+}
+
 sub __makeBackend {
 	my ($self, $translation) = @_;
 	return Chleb::Bible::Backend->new({

--- a/t/votd.t
+++ b/t/votd.t
@@ -165,6 +165,45 @@ sub testV2TranslationIndependentDailyVerse {
 	return EXIT_SUCCESS;
 }
 
+sub testV2BibleTranslationsShareDailyReference {
+	my ($self) = @_;
+	plan skip_all => 'ASV, KJV and Pickthall test data are not installed'
+	    unless ($self->hasTranslation('asv') && $self->hasTranslation('kjv')
+	        && $self->hasTranslation('pickthall'));
+	plan tests => 5;
+
+	my $when = '2026-08-06T12:00:00+0100';
+	my @cases = (
+		[ [ 'asv' ], [ 'asv:2 Samuel 3:19' ] ],
+		[ [ 'kjv' ], [ 'kjv:2 Samuel 3:19' ] ],
+		[ [ 'asv', 'kjv' ], [ 'asv:2 Samuel 3:19', 'kjv:2 Samuel 3:19' ] ],
+		[ [ 'kjv', 'asv' ], [ 'kjv:2 Samuel 3:19', 'asv:2 Samuel 3:19' ] ],
+		[ [ 'all' ], [ 'asv:2 Samuel 3:19', 'kjv:2 Samuel 3:19', 'pickthall:Quran 53:36' ] ],
+	);
+
+	foreach my $case (@cases) {
+		my ($translations, $expected) = @$case;
+		my $verses = $self->sut->votd({
+			version      => 2,
+			when         => $when,
+			parental     => 0,
+			translations => $translations,
+		});
+		my %seenTranslation;
+		my @references = map {
+			join(':', $_->book->bible->translation, sprintf('%s %d:%d',
+				$_->book->longName, $_->chapter->ordinal, $_->ordinal));
+		} grep {
+			!$seenTranslation{$_->book->bible->translation}++;
+		} @$verses;
+
+		is_deeply(\@references, $expected,
+			'Bible VoTD references share the canonical reference and preserve request order');
+	}
+
+	return EXIT_SUCCESS;
+}
+
 sub testParentalTerm {
 	my ($self) = @_;
 	plan tests => 2;


### PR DESCRIPTION
Anchor compatible Bible translations to one canonical reference while retaining deterministic ordinal selection for incompatible canons. Version shared ordinal-cache entries so stale mappings are ignored.