### PR TITLE
🔇 fix warnings in test suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,7 @@ Key files and directories:
   emojis that exist under `data/gitmoji/`.
 - Add `Co-Authored-By: Codex <noreply@openai.com>` to commits made by Codex.
 - Keep commit messages focused on the change being made.
+- Wrap long commit-message body or description lines at 120 columns.
 
 ## Agent Notes
 

--- a/t/Search_Query_thesaurus.t
+++ b/t/Search_Query_thesaurus.t
@@ -13,9 +13,10 @@ use File::Temp qw(tempfile);
 use IO::Uncompress::Gunzip qw(gunzip $GunzipError);
 use Moose;
 
+use lib 't/lib';
 use lib 'externals/libtest-module-runnable-perl/lib';
 
-extends 'Test::Module::Runnable';
+extends 'Test::Module::Runnable::Local';
 
 use Chleb::Bible;
 use Chleb::Bible::Backend;
@@ -24,7 +25,9 @@ use Test::More 0.96;
 
 sub setUp {
 	my ($self, %params) = @_;
-	$self->SUPER::setUp(%params);
+	if (EXIT_SUCCESS != $self->SUPER::setUp(%params)) {
+		return EXIT_FAILURE;
+	}
 
 	my ($handle, $database) = tempfile(SUFFIX => '.sqlite', UNLINK => 1);
 	close($handle) or die("Cannot close temporary database: $!\n");

--- a/t/Server_Dancer2_notFound.t
+++ b/t/Server_Dancer2_notFound.t
@@ -38,9 +38,10 @@ use strict;
 use warnings;
 use Moose;
 
+use lib 't/lib';
 use lib 'externals/libtest-module-runnable-perl/lib';
 
-extends 'Test::Module::Runnable';
+extends 'Test::Module::Runnable::Local';
 
 use Chleb::Server::Dancer2;
 use Chleb::Server::MediaType;

--- a/t/Server_Dancer2_notFound.t
+++ b/t/Server_Dancer2_notFound.t
@@ -162,6 +162,9 @@ sub testRoutePreservesJson {
 sub testDeliberateInternalServerErrorRoute {
 	my ($self) = @_;
 	plan tests => 8;
+	my $stderr = q{};
+	open(my $stderrHandle, '>', \$stderr) or die("Cannot capture STDERR: $!\n");
+	local *STDERR = $stderrHandle;
 
 	my $app = Chleb::Server::Dancer2->to_app();
 	test_psgi($app, sub {
@@ -217,6 +220,9 @@ sub testAllDeliberateHttpErrorRoutes {
 	my ($self) = @_;
 	my @codes = @{ Chleb::Server::Dancer2::httpErrorCodes() };
 	plan tests => scalar(@codes) * 4;
+	my $stderr = q{};
+	open(my $stderrHandle, '>', \$stderr) or die("Cannot capture STDERR: $!\n");
+	local *STDERR = $stderrHandle;
 
 	my $app = Chleb::Server::Dancer2->to_app();
 	test_psgi($app, sub {

--- a/t/TokenRepository_Local.t
+++ b/t/TokenRepository_Local.t
@@ -67,9 +67,9 @@ sub setUp {
 
 	$self->dic(Chleb::DI::Container->instance);
 	$self->dic->configPaths(['etc-local']);
+	$self->dic->logger(Chleb::DI::MockLogger->new());
 	$self->dic->time->setMockedTime(2_000_000_000);
 	$self->sut(Chleb::Token::Repository::Local->new({ dic => $self->dic }));
-	$self->__mockLogger();
 
 	return EXIT_SUCCESS;
 }
@@ -202,12 +202,6 @@ sub testLoadNotInvalidHash {
 	ok(!$token, 'token not set');
 
 	return EXIT_SUCCESS;
-}
-
-sub __mockLogger {
-	my ($self) = @_;
-	$self->sut->dic->logger(Chleb::DI::MockLogger->new());
-	return;
 }
 
 package main;


### PR DESCRIPTION
The test suite is logging annoying messages, which mean the output is not so clear.